### PR TITLE
[wip] Add: first draft of parsing basic structure elements

### DIFF
--- a/resources/structure.ebnf
+++ b/resources/structure.ebnf
@@ -1,0 +1,33 @@
+document = (heading | section) node* | ''
+
+section = element+
+
+<element> = paragraph
+
+paragraph = empty-lines / content
+content = content-line content-line*
+empty-lines = empty-line empty-line*
+(* anything that doesn't start with a star *)
+<content-line> = #'^[^*\n]+' <eol>
+<empty-line> = #'\s+'? <eol>
+
+<node> = heading (node* | '')
+
+heading = headline section? node*
+
+<headline> = stars priority? comment-token? title? (<eol> | tags <eol>)
+
+stars = #'^\*+' <s>+
+priority = <"[#"> #"[A-Z]" <"]"> <s>
+comment-token = <"COMMENT"> <s>
+title =  #'.*' (* anything but newline *)
+tags = <':'> ( tag <':'> )+
+<tag> = #'[a-zA-Z0-9_@#%]+'
+
+<s> = #'\s+'
+<word> = letter+
+<number> = digit+
+<letter> = #'[a-zA-Z\-]+'
+<digit> = #'[0-9]'
+<newline> = '\n'
+<eol> = <#'\n|$'>

--- a/src/org_parser/parser.cljc
+++ b/src/org_parser/parser.cljc
@@ -3,3 +3,5 @@
 
 
 (def org (insta/parser (clojure.java.io/resource "org.ebnf")))
+
+(def structure (insta/parser (clojure.java.io/resource "structure.ebnf")))

--- a/test/fixtures/basic-structure.org
+++ b/test/fixtures/basic-structure.org
@@ -1,0 +1,18 @@
+An introduction.
+
+* A Headline
+
+  Some text.
+
+** Sub-Topic 1
+
+** Sub-Topic 2
+
+*** Additional entry
+
+    More text.
+
+* Level One Headline
+
+A pargraph
+maybe?

--- a/test/org_parser/structure_test.cljc
+++ b/test/org_parser/structure_test.cljc
@@ -1,0 +1,36 @@
+(ns org-parser.structure-test
+  (:require [org-parser.parser :as parser]
+            [clojure.walk :as walk]
+            #?(:clj [clojure.test :as t :refer :all]
+               :cljs [cljs.test :as t :include-macros true])))
+
+(def parse #(parser/structure %))
+
+(defn input-file [orgfile]
+  (slurp (str (System/getProperty "user.dir") "/test/fixtures/" orgfile)))
+
+(defn heading? [vec]
+  (= :heading (first vec)))
+
+(deftest basic
+  (testing "an empty file"
+    (is (= [:document] (parse ""))))
+  (testing "a file with one section"
+    (is (= [:document
+            [:section [:paragraph [:content "Foo."]]]]
+           (parse "Foo."))))
+  (testing "a file with one heading"
+    (is (= [:document [:heading [:stars "*"] [:title "Heading"]]]
+           (parse "* Heading")))))
+
+(deftest simpleOrgFile
+  (let [document (parse (input-file "basic-structure.org"))
+        contents (rest document)]
+    (testing "it has an initial section"
+      (let [[first-section] contents
+            [type] first-section]
+        (is (= :section type))))
+    (testing "it has two top level headings"
+      ;; expected to be red
+      (let [top-headings (walk/walk #(if (= :heading (first %)) 1 0) identity contents)]
+        (is (= 2 (apply + top-headings)))))))


### PR DESCRIPTION
I realized that the existing `org.ebnf` file is just aiming at parsing individual lines. I'm sure this will be useful, but as I started looking at property drawers and decided to try working top-down based on the org specification.

This is just a start, but is one step on the way of building the tree structure.  Currently, it does not properly switch heading levels while reading the tree. I kept everything in separate files for the time being, as it was easier for me to deal with while learning how everything works.