### PR TITLE
Parse content text that can contain style, links, footnotes, timestamps, ...

### DIFF
--- a/README.org
+++ b/README.org
@@ -27,7 +27,7 @@ The biggest milestones are:
       - [X] Links
       - [-] Text links
       - [-] Styled text
-      - [ ] Text that can contain style, links, footnotes, timestamps, ...
+      - [-] Text that can contain style, links, footnotes, timestamps, ...
 
 - [ ] Setup basic [instaparse transformations](http://xahlee.info/clojure/clojure_instaparse_transform.html) from the parse tree to a
       higher-level structure.

--- a/README.org
+++ b/README.org
@@ -19,7 +19,7 @@ This project is work-in-progress. It is not ready for production yet.
 
 The biggest milestones are:
 
-- [-] Finish [EBNF parser](http://xahlee.info/clojure/clojure_instaparse_grammar_syntax.html) to support most orgmode syntax
+- [-] Finish [[http://xahlee.info/clojure/clojure_instaparse_grammar_syntax.html][EBNF parser]] to support most orgmode syntax
       - [X] Headlines and orgmode `#+*` stuff
       - [X] More features
       - [X] Footnotes (?)
@@ -29,7 +29,7 @@ The biggest milestones are:
       - [-] Styled text
       - [-] Text that can contain style, links, footnotes, timestamps, ...
 
-- [ ] Setup basic [instaparse transformations](http://xahlee.info/clojure/clojure_instaparse_transform.html) from the parse tree to a
+- [ ] Setup basic [[http://xahlee.info/clojure/clojure_instaparse_transform.html][instaparse transformations]] from the parse tree to a
       higher-level structure.
 
 - [ ] Transformations to higher-level structure: catch up with orgmode

--- a/README.org
+++ b/README.org
@@ -25,8 +25,9 @@ The biggest milestones are:
       - [X] Footnotes (?)
       - [X] Timestamps
       - [X] Links
-      - [ ] Markup
-      - [ ] Text that can contain markup, links, footnotes, timestamps, ...
+      - [-] Text links
+      - [-] Styled text
+      - [ ] Text that can contain style, links, footnotes, timestamps, ...
 
 - [ ] Setup basic [instaparse transformations](http://xahlee.info/clojure/clojure_instaparse_transform.html) from the parse tree to a
       higher-level structure.

--- a/README.org
+++ b/README.org
@@ -20,7 +20,7 @@ This project is work-in-progress. It is not ready for production yet.
 The biggest milestones are:
 
 - [-] Finish [[http://xahlee.info/clojure/clojure_instaparse_grammar_syntax.html][EBNF parser]] to support most orgmode syntax
-      - [X] Headlines and orgmode `#+*` stuff
+      - [X] Headlines and orgmode =#+*= stuff
       - [X] More features
       - [X] Footnotes (?)
       - [X] Timestamps

--- a/README.org
+++ b/README.org
@@ -2,6 +2,8 @@
 
 =org-parser= is a parser for the [[https://orgmode.org/][Org mode]] markup language for Emacs.
 
+It can be used from JavaScript, Java, and Clojure!
+
 To our knowledge, there is no formal specification of Org. But there
 is a [[https://orgmode.org/worg/dev/org-syntax.html]['spec' written in prose]] which lead to the [[https://orgmode.org/worg/dev/org-element-api.html][reference
 implementation of Org in Emacs]].
@@ -10,6 +12,36 @@ Working on our web-based Org implementation [[https://github.com/200ok-ch/organi
 brittle existing libraries can be. It would be nice to have a proper
 BNF based parser and a set of tests behind that. =org-parser=
 strives to be that!
+
+** Project State
+
+This project is work-in-progress. It is not ready for production yet.
+
+The biggest milestones are:
+
+- [-] Finish [EBNF parser](http://xahlee.info/clojure/clojure_instaparse_grammar_syntax.html) to support most orgmode syntax
+      - [X] Headlines and orgmode `#+*` stuff
+      - [X] More features
+      - [X] Footnotes (?)
+      - [X] Timestamps
+      - [X] Links
+      - [ ] Markup
+      - [ ] Text that can contain markup, links, footnotes, timestamps, ...
+
+- [ ] Setup basic [instaparse transformations](http://xahlee.info/clojure/clojure_instaparse_transform.html) from the parse tree to a
+      higher-level structure.
+
+- [ ] Transformations to higher-level structure: catch up with orgmode
+      features supported already by the EBNF parser
+
+Not ready for production yet, *but it can already be useful* for you:
+E.g. if your script needs to parse parts of orgmode features, our EBNF
+parser probably already supports that. Do not underestimate
+e.g. timestamps. Use our well-tested parser to disassemble it in its
+parts, instead of trying to write a poor and ugly regex that is only
+capable of a subset of orgmode's timestamps ;)
+
+Don't hesitate to contribute!
 
 ** Development
 

--- a/README.org
+++ b/README.org
@@ -19,8 +19,8 @@ This project is work-in-progress. It is not ready for production yet.
 
 The biggest milestones are:
 
-- [-] Finish [[http://xahlee.info/clojure/clojure_instaparse_grammar_syntax.html][EBNF parser]] to support most orgmode syntax
-      - [X] Headlines and orgmode =#+*= stuff
+- [-] Finish [[http://xahlee.info/clojure/clojure_instaparse_grammar_syntax.html][EBNF parser]] to support most Org mode syntax
+      - [X] Headlines and Org mode =#+*= stuff
       - [X] More features
       - [X] Footnotes (?)
       - [X] Timestamps
@@ -32,15 +32,15 @@ The biggest milestones are:
 - [ ] Setup basic [[http://xahlee.info/clojure/clojure_instaparse_transform.html][instaparse transformations]] from the parse tree to a
       higher-level structure.
 
-- [ ] Transformations to higher-level structure: catch up with orgmode
-      features supported already by the EBNF parser
+- [ ] Transformations to higher-level structure: catch up with Org mode
+      features supported already by the EBNF parser.
 
 Not ready for production yet, *but it can already be useful* for you:
-E.g. if your script needs to parse parts of orgmode features, our EBNF
+E.g. if your script needs to parse parts of Org mode features, our EBNF
 parser probably already supports that. Do not underestimate
 e.g. timestamps. Use our well-tested parser to disassemble it in its
 parts, instead of trying to write a poor and ugly regex that is only
-capable of a subset of orgmode's timestamps ;)
+capable of a subset of Org mode's timestamps ;)
 
 Don't hesitate to contribute!
 

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -259,6 +259,10 @@ macro-args = <''> | macro-arg ( <','> macro-arg )*
    this is configurable, we parse any name that looks valid.
 
    C-c C-x \ (org-toggle-pretty-entities)
+
+   TODO Implement other latex syntax:
+        \command[x]{y}{z}, \( \), \[ \], $$ $$, $ $
+	text-entity must be edited to also match \command[]{}s
  *)
 text-entity = ""
 text-entity = <'\\'> entity-name ( entity-braces | ε & <#"[^a-zA-Z]|$"> )

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -235,7 +235,7 @@ link-description = link-inside
    https://orgmode.org/manual/External-Links.html
    TODO compare to orgmode source/regexes?
  *)
-link-ext = link-ext-file / link-ext-other / link-ext-web
+link-ext = link-ext-file / link-ext-other
 
 (* TODO missing: backslash escapes, ssh support *)
 (* TODO link-text-file-location parsed? no because link-inside is
@@ -251,10 +251,6 @@ link-file-loc-string = link-inside
 link-ext-other = link-url-scheme <':'> link-url-rest
 link-url-scheme = #"[a-z]+"
 link-url-rest = link-inside
-
-(* Web address without http(s) protocol
-   from https://stackoverflow.com/a/3809435 *)
-link-ext-web = #"[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)"
 
 (* Internal Links
    https://orgmode.org/manual/Internal-Links.html

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -237,11 +237,9 @@ link-description = link-inside
  *)
 link-ext = link-ext-file / link-ext-other
 
-(* TODO missing: backslash escapes, ssh support *)
-(* TODO link-text-file-location parsed? no because link-inside is
-        greedy. temporary fix: parse filenames without colon: *)
-<link-inside-filename> = #"[^]:]*"
+(* TODO missing: ssh support *)
 link-ext-file = ( <'file:'> | & #"\.?/" ) link-inside-filename [ link-ext-file-location ]
+<link-inside-filename> = #"(\\\[|\\\]|\\\\|:(?!:)|[^:\[\]])*"
 <link-ext-file-location> = <'::'> ( link-file-loc-lnum / link-file-loc-headline / link-file-loc-customid / link-file-loc-string )
 link-file-loc-lnum = #"\d+"
 link-file-loc-headline = <'*'> link-inside

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -183,15 +183,15 @@ text = ( link-format / text-link / text-styled / text-normal )*
    "Text in the code and verbatim string is not processed for Org specific syntax;"
    Implies that the rest can be nested.
  *)
-text-styled = text-sty-bold / text-sty-italic / text-sty-underlined / text-sty-verbatim / text-sty-code / text-sty-strikethrough
+text-styled = text-sty-bold / text-sty-italic / text-sty-underlined / text-sty-strikethrough / text-sty-verbatim / text-sty-code
 
 (* TODO simplest possible solution; ignores ways of escaping and does not allow the delim to appear inside *)
-text-sty-bold          = <'*'> #"[^*]+" <'*'>
-text-sty-italic        = <'/'> #"[^/]+" <'/'>
-text-sty-underlined    = <'_'> #"[^_]+" <'_'>
+text-sty-bold          = <'*'> text <'*'>
+text-sty-italic        = <'/'> text <'/'>
+text-sty-underlined    = <'_'> text <'_'>
+text-sty-strikethrough = <'+'> text <'+'>
 text-sty-verbatim      = <'='> #"[^=]+" <'='>
 text-sty-code          = <'~'> #"[^~]+" <'~'>
-text-sty-strikethrough = <'+'> #"[^+]+" <'+'>
 
 (* TODO compare with org mode regexes; support more protocols *)
 text-link = text-link-angled / text-link-normal

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -3,6 +3,7 @@ S = line*
 <line> = (empty-line / head-line / affiliated-keyword-line / keyword-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-begin-line / drawer-end-line / list-item-line / footnote-line / content-line) eol
 
 empty-line = "" | #"\s+"
+(* TODO same as title text below. *)
 content-line = #".*"
 
 <eol> = <#'\n|$'>
@@ -13,6 +14,7 @@ head-line = stars [s priority] [s comment-token] s title [s tags]
 stars = #'\*+'
 priority = <"[#"> #"[A-Z]" <"]">
 comment-token = <"COMMENT">
+(* TODO title text is more than just words; e.g. formatting and timestamps are allowed. -> generic text? *)
 title = !tags word {s !tags word}
 tags = <':'> ( tag <':'> )+
 <tag> = #'[a-zA-Z0-9_@#%]+'

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -193,17 +193,37 @@ text-sty-strikethrough = <'+'> text <'+'>
 text-sty-verbatim      = <'='> #"[^=]+" <'='>
 text-sty-code          = <'~'> #"[^~]+" <'~'>
 
-(* TODO compare with org mode regexes; support more protocols *)
-text-link = text-link-angled / text-link-normal
-text-link-angled = <'<'> text-link-url <'>'>
-text-link-normal = text-link-url
-<text-link-url> = #"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)"
-(* regex taken from: https://stackoverflow.com/a/3809435 *)
+(* taken from org-emph-re/org-verbatim-re *)
+before-sty = #"[- ('\"{]|"
 
-(* TODO how to prevent greedyness? e.g. not parse text-link-normal (-> look-ahead?) *)
-(* Simple work-around: parse characters as long there are no style delimiters – but always parse one character.
-   This works because when parsing, text-normal is tried last.
-   It can result in multiple subsequent text-normal which will be concated in a later transform step.
+(* first and last character must not be whitespace. that's why it's not just text *)
+text-inside-sty = ( link-format / footnote-link / text-link / text-styled / text-inside-sty-normal )*
+(* TODO space works? includes newline? *)
+text-inside-sty-normal = #"([^ ]|[^ ].*?[^ ])(?=\*([- .,:!?;'\")}\[]|$))"
+
+(* There are 4 types of links: radio link (not subject to this
+   parser), angle link, plain link, and regular link
+
+   https://orgmode.org/worg/dev/org-syntax.html#Links
+
+   Plain links are defined here but probably never matched because
+   they have no characteristic start delimiter.
+
+   Protocol must match org-link-types-re but are here defined more
+   open. We can't rely on variable org settings.
+ *)
+text-link = text-link-angle / text-link-plain
+text-link-angle = <'<'> link-url-scheme <':'> text-link-angle-path <'>'>
+text-link-angle-path = #"[^\]<>\n]+"
+text-link-plain = link-url-scheme <':'> text-link-plain-path
+text-link-plain-path = #"[^\s()<>]+(\w|[^\s[:punct:]]/)"
+
+(* TODO how to prevent greedyness? e.g. not parse text-link-plain (-> look-ahead?) *)
+(* Simple work-around: parse characters as long there is no
+   characteristic delimiter – but always parse at least one character.
+   This works so far because when parsing, text-normal is tried last.
+   It can result in multiple subsequent text-normal which will be
+   concated in a later transform step.
  *)
 text-normal = #".[^*/_=~+\[<^]*"
 
@@ -254,7 +274,8 @@ link-file-loc-customid = <'#'> link-inside
 link-file-loc-string = link-inside
 
 link-ext-other = link-url-scheme <':'> link-url-rest
-link-url-scheme = #"[a-z]+"
+(* see org-link-types-re *)
+link-url-scheme = #"[a-z][a-z0-9]+"
 link-url-rest = link-inside
 
 (* Internal Links

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -176,7 +176,7 @@ ts-mod-unit = #'[hdwmy]'
  *)
 
 (* TODO handle latex code? *)
-text = ( link-format / footnote-link / text-link / text-styled / text-sub / text-sup / text-normal )*
+text = ( link-format / footnote-link / text-link / text-target / text-radio-target / text-styled / text-sub / text-sup / text-normal )*
 
 (* Emphasis and Monospace (font style markup)
    https://orgmode.org/manual/Emphasis-and-Monospace.html
@@ -235,6 +235,11 @@ text-sup = <'^'> ( text-subsup-curly | text-subsup-word )
 text-subsup-word = #"[a-zA-Z0-9]+"
 text-subsup-curly = <'{'> #"[^{}]*" <'}'>
 
+(* https://orgmode.org/worg/dev/org-syntax.html#Targets_and_Radio_Targets *)
+text-target = <'<<'> text-target-name <'>>'>
+text-target-name = #"[^<>\n\s][^<>\n]*[^<>\n\s]" | #"[^<>\n\s]"
+(* TODO for now, don't allow text objects *)
+text-radio-target = <'<<<'> text-target-name <'>>>'>
 
 (* Hyperlinks
    https://orgmode.org/guide/Hyperlinks.html

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -65,12 +65,14 @@ dynamic-block-end-line = <'#+END:'>
 dynamic-block-name = anything-but-whitespace
 dynamic-block-parameters = anything-but-newline
 
-footnote-line = <'['> footnote-label <'] '> footnote-contents
-footnote-label = (number | <'fn:'> footnote-word)
-<number> = #"\d+"
-<footnote-word> = #"[a-zA-Z0-9-_]+"
-(* TODO footnote-context should be text *)
-footnote-contents = anything-but-newline
+(* Footnotes
+   https://www.gnu.org/software/emacs/manual/html_node/org/Footnotes.html
+ *)
+footnote-link = <'[fn:'> [ fn-label ] <':'> fn-text-inline <']'> / <'[fn:'> fn-label <']'>
+footnote-line = <'[fn:'> fn-label <'] '> fn-text
+fn-label = #"[a-zA-Z0-9-_]+"
+<fn-text> = text
+<fn-text-inline> = #"[^\[\]]*"
 
 list-item-line = ( list-item-bullet | list-item-counter list-item-counter-suffix ) <" "> (list-item-checkbox <" "> list-item-contents / list-item-contents)
 list-item-bullet = #"[*\-+]"
@@ -175,8 +177,7 @@ ts-mod-unit = #'[hdwmy]'
  *)
 
 (* TODO handle latex code? *)
-(* TODO missing: footnotes; footnote must come before link *)
-text = ( link-format / text-link / text-styled / text-normal )*
+text = ( link-format / footnote-link / text-link / text-styled / text-normal )*
 
 (* Emphasis and Monospace (font style markup)
    https://orgmode.org/manual/Emphasis-and-Monospace.html

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -177,7 +177,7 @@ ts-mod-unit = #'[hdwmy]'
  *)
 
 (* TODO handle latex code? *)
-text = ( link-format / footnote-link / text-link / text-target / text-radio-target / text-styled / text-sub / text-sup / text-normal )*
+text = ( link-format / footnote-link / text-link / text-target / text-radio-target / text-macro / text-styled / text-sub / text-sup / text-normal )*
 
 (* Emphasis and Monospace (font style markup)
    https://orgmode.org/manual/Emphasis-and-Monospace.html
@@ -226,7 +226,7 @@ text-link-plain-path = #"[^\s()<>]+(\w|[^\s[:punct:]]/)"
    It can result in multiple subsequent text-normal which will be
    concated in a later transform step.
  *)
-text-normal = #".[^*/_=~+\[<^]*"
+text-normal = #".[^*/_=~+\[<{^]*"
 
 (* Superscript and subscript
    https://orgmode.org/worg/dev/org-syntax.html#Subscript_and_Superscript
@@ -242,6 +242,14 @@ text-target = <'<<'> text-target-name <'>>'>
 text-target-name = #"[^<>\n\s][^<>\n]*[^<>\n\s]" | #"[^<>\n\s]"
 (* TODO for now, don't allow text objects *)
 text-radio-target = <'<<<'> text-target-name <'>>>'>
+
+(* https://orgmode.org/worg/dev/org-syntax.html#Macros *)
+text-macro = <'{{{'> macro-name <'('> macro-args <')'> <'}}}'>
+macro-name = #"[a-zA-Z][-\w]*"
+macro-args = <''> | macro-arg ( <','> macro-arg )*
+(* "ARGUMENTS can contain anything but “}}}” string."
+   Comma must be escaped; ")" is only allowed when not followed by "}}}".
+<macro-arg> = #"(\\,|[^)},]|\}(?!\}\})|\)(?!\}\}\}))*"
 
 (* Hyperlinks (regular links)
    https://orgmode.org/guide/Hyperlinks.html

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -91,8 +91,7 @@ keyword-value = anything-but-newline
 node-property-line = <':'> node-property-name [node-property-plus] <':'> [<' '> node-property-value]
 node-property-name = #"[^\s:+]+"
 node-property-plus = <"+">
-(* TODO footnote-context should be text *)
-node-property-value = anything-but-newline
+node-property-value = text
 
 
 (* timestamps

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -243,7 +243,7 @@ text-target-name = #"[^<>\n\s][^<>\n]*[^<>\n\s]" | #"[^<>\n\s]"
 (* TODO for now, don't allow text objects *)
 text-radio-target = <'<<<'> text-target-name <'>>>'>
 
-(* Hyperlinks
+(* Hyperlinks (regular links)
    https://orgmode.org/guide/Hyperlinks.html
    https://orgmode.org/manual/Link-Format.html
 
@@ -255,7 +255,7 @@ text-radio-target = <'<<<'> text-target-name <'>>>'>
 (* Any text inside link brackets [[...][...]].
    Backslash is the escape character for itself and opening/closing brackets.
  *)
-<link-inside> = #"(\\\[|\\\]|\\\\|[^]\[])*"
+<link-inside> = #"(\\\[|\\\]|\\\\|[^\[\]])+"
 
 link-format = <'[['> link <']]'> / <'[['> link <']['> link-description <']]'>
 
@@ -267,18 +267,19 @@ link-description = link-inside
 
 (* External Links
    https://orgmode.org/manual/External-Links.html
-   TODO compare to orgmode source/regexes?
- *)
-link-ext = link-ext-file / link-ext-other
+   https://orgmode.org/worg/dev/org-syntax.html#Links *)
+link-ext = link-ext-file / link-ext-id / link-ext-other
 
 (* TODO missing: ssh support *)
 link-ext-file = ( <'file:'> | & #"\.?/" ) link-inside-filename [ link-ext-file-location ]
-<link-inside-filename> = #"(\\\[|\\\]|\\\\|:(?!:)|[^:\[\]])*"
+<link-inside-filename> = #"(\\\[|\\\]|\\\\|:(?!:)|[^:\[\]])+"
 <link-ext-file-location> = <'::'> ( link-file-loc-lnum / link-file-loc-headline / link-file-loc-customid / link-file-loc-string )
 link-file-loc-lnum = #"\d+"
 link-file-loc-headline = <'*'> link-inside
 link-file-loc-customid = <'#'> link-inside
 link-file-loc-string = link-inside
+
+link-ext-id = <"id:"> #"[0-9a-fA-F-]+"
 
 link-ext-other = link-url-scheme <':'> link-url-rest
 (* see org-link-types-re *)

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -6,7 +6,7 @@
 
 S = line*
 
-<line> = (empty-line / head-line / affiliated-keyword-line / keyword-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-begin-line / drawer-end-line / list-item-line / footnote-line / literal-line / content-line) eol
+<line> = (empty-line / head-line / affiliated-keyword-line / keyword-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-begin-line / drawer-end-line / list-item-line / footnote-line / fixed-width-line / content-line) eol
 
 empty-line = "" | #"\s+"
 (* TODO same as title text below. *)
@@ -27,11 +27,12 @@ title = !tags word {s !tags word}
 tags = <':'> ( tag <':'> )+
 <tag> = #'[a-zA-Z0-9_@#%]+'
 
-(* https://orgmode.org/manual/Literal-Examples.html *)
-(* TODO need to preserve leading space? *)
-literal-line = ll-leading-space <':'> ll-text
-ll-leading-space = #"[\t ]*"
-ll-text = #".*"
+(* Fixed Width Areas
+   https://orgmode.org/worg/dev/org-syntax.html#Fixed_Width_Areas
+   https://orgmode.org/manual/Literal-Examples.html *)
+fixed-width-line = fw-head fw-rest
+fw-head = #"\s*:(?= |$)"
+fw-rest = #".*"
 
 affiliated-keyword-line = <"#+"> (key | attr) <": "> value
 optional = <"["> optional-value <"]">

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -131,7 +131,12 @@ ts-inner-wo-time = ts-date [<' '+> ts-day]
 
 ts-date = #"\d{4}-\d{2}-\d{2}"
 
-ts-time = #"\d{1,2}:\d{2}(:\d{2})?"
+(* It is possible to implement stricter rules, e.g. regex [012]?\d for hours.
+   However, it would add complexity and date/time must be validated at
+   a higher level anyway. Additionally, orgmode C-c C-c seems to add
+   date and time; if time is "too big" and points to the next day, the
+   timestamp date is updated accordingly. *)
+ts-time = #"\d{1,2}:\d{2}(:\d{2})?([AaPp][Mm])?"
 
 (* TODO Is there a class for letters? *)
 (* TODO Does \s also match \n\r? If yes (like in JS), there is redundant \r\n in code above. *)

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -163,22 +163,51 @@ ts-mod-unit = #'[hdwmy]'
 
  *)
 
+(* TODO footnote must come before link *)
 text = #".*" / link
 
 (* Hyperlinks
    https://orgmode.org/guide/Hyperlinks.html
+   https://orgmode.org/manual/Link-Format.html
+
+   URIs in text, optionally wrapped in <>, are recognized as links.
+   The general link format is [[]] and [[][]].
  *)
 
-link = <'[['> link-uri <']]'> / <'[['> link-uri <']['> link-description <']]'>
-link-uri = #"[]]*"
+<link-inside> = #"[^]]*"
+
+link-format = <'[['> link <']]'> / <'[['> link <']['> link-description <']]'>
+(* TODO link and description must support backslash escape for ], [, (and \) *)
+link = link-ext / link-int
 (* TODO do description must support markup? *)
-link-description = #"[]]*"
+link-description = link-inside
 
 (* External Links
    https://orgmode.org/manual/External-Links.html
-   TODO reuse orgmode source/regexes?
+   TODO compare with orgmode source/regexes?
  *)
+link-ext = link-ext-file / link-ext-other / link-ext-web
+
+(* TODO backslash escapes, ssh support *)
+(* TODO link-text-file-location parsed? no because link-inside is
+        greedy. temporary fix: parse filenames without colon: *)
+<link-inside-filename> = #"[^]:]*"
+link-ext-file = ( <'file:'> | & #"\.?/" ) link-inside-filename [ link-ext-file-location ]
+<link-ext-file-location> = <'::'> ( link-file-loc-lnum / link-file-loc-headline / link-file-loc-customid / link-file-loc-string )
+link-file-loc-lnum = #"\d+"
+link-file-loc-headline = <'*'> link-inside
+link-file-loc-customid = <'#'> link-inside
+link-file-loc-string = link-inside
+
+link-ext-other = link-url-scheme <':'> link-url-rest
+link-url-scheme = #"[a-z]+"
+link-url-rest = link-inside
+
+(* Web address without http(s) protocol
+   from https://stackoverflow.com/a/3809435 *)
+link-ext-web = #"[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)"
 
 (* Internal Links
    https://orgmode.org/manual/Internal-Links.html
  *)
+link-int = #"[^]]*"

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -166,29 +166,37 @@ ts-mod-unit = #'[hdwmy]'
 (* TODO footnote must come before link *)
 text = #".*" / link
 
+
+
+
 (* Hyperlinks
    https://orgmode.org/guide/Hyperlinks.html
    https://orgmode.org/manual/Link-Format.html
 
    URIs in text, optionally wrapped in <>, are recognized as links.
    The general link format is [[]] and [[][]].
+
  *)
 
+(* Any text inside link brackets [...] *)
+(* TODO link and description must support backslash escape for ], [, (and \) *)
 <link-inside> = #"[^]]*"
 
 link-format = <'[['> link <']]'> / <'[['> link <']['> link-description <']]'>
-(* TODO link and description must support backslash escape for ], [, (and \) *)
+
+(* > If the link does not look like a URL, it is considered to be internal in the current file.
+   - from orgmode guide. Hence the ordered alternatives: *)
 link = link-ext / link-int
-(* TODO do description must support markup? *)
+(* TODO does description must support markup? *)
 link-description = link-inside
 
 (* External Links
    https://orgmode.org/manual/External-Links.html
-   TODO compare with orgmode source/regexes?
+   TODO compare to orgmode source/regexes?
  *)
 link-ext = link-ext-file / link-ext-other / link-ext-web
 
-(* TODO backslash escapes, ssh support *)
+(* TODO missing: backslash escapes, ssh support *)
 (* TODO link-text-file-location parsed? no because link-inside is
         greedy. temporary fix: parse filenames without colon: *)
 <link-inside-filename> = #"[^]:]*"
@@ -209,5 +217,8 @@ link-ext-web = #"[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9
 
 (* Internal Links
    https://orgmode.org/manual/Internal-Links.html
+
+   Here, link-file-loc-string works different than in link-ext-file:
+   It is not text search but a link to <<id>> or #+NAME: id. See manual.
  *)
-link-int = #"[^]]*"
+link-int = link-file-loc-headline / link-file-loc-customid / link-file-loc-string

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -1,5 +1,6 @@
 
 (* Main sources:
+   - Org Mode Spec: https://orgmode.org/worg/dev/org-syntax.html
    - Org Mode Manual: https://www.gnu.org/software/emacs/manual/html_mono/org.html
    - Org Mode Compact Guide: https://orgmode.org/guide/
 *)

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -193,8 +193,10 @@ text-sty-bold          = <'*'> text <'*'>
 text-sty-italic        = <'/'> text <'/'>
 text-sty-underlined    = <'_'> text <'_'>
 text-sty-strikethrough = <'+'> text <'+'>
-text-sty-verbatim      = <'='> #"[^=]+" <'='>
-text-sty-code          = <'~'> #"[^~]+" <'~'>
+(* https://orgmode.org/worg/dev/org-syntax.html#Emphasis_Markers is wrong at this point:
+   The BORDER character in =BxB= must not be whitespace but can be [,'"]. *)
+text-sty-verbatim      = <'='> #"([^\s]|[^\s].*?[^\s])(?==($|[- \t.,:!?;'\")}\[]))" <'='>
+text-sty-code          = <'~'> #"([^\s]|[^\s].*?[^\s])(?=~($|[- \t.,:!?;'\")}\[]))" <'~'>
 
 (* taken from org-emph-re/org-verbatim-re *)
 before-sty = #"[- ('\"{]|"

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -177,7 +177,7 @@ ts-mod-unit = #'[hdwmy]'
  *)
 
 (* TODO handle latex code? *)
-text = ( link-format / footnote-link / text-link / text-target / text-radio-target / text-macro / text-styled / text-sub / text-sup / text-normal )*
+text = ( link-format / footnote-link / text-link / text-target / text-radio-target / text-entity / text-macro / text-styled / text-sub / text-sup / text-normal )*
 
 (* Emphasis and Monospace (font style markup)
    https://orgmode.org/manual/Emphasis-and-Monospace.html
@@ -226,7 +226,7 @@ text-link-plain-path = #"[^\s()<>]+(\w|[^\s[:punct:]]/)"
    It can result in multiple subsequent text-normal which will be
    concated in a later transform step.
  *)
-text-normal = #".[^*/_=~+\[<{^]*"
+text-normal = #".[^*/_=~+\[<{^\\]*"
 
 (* Superscript and subscript
    https://orgmode.org/worg/dev/org-syntax.html#Subscript_and_Superscript
@@ -250,6 +250,20 @@ macro-args = <''> | macro-arg ( <','> macro-arg )*
 (* "ARGUMENTS can contain anything but “}}}” string."
    Comma must be escaped; ")" is only allowed when not followed by "}}}".
 <macro-arg> = #"(\\,|[^)},]|\}(?!\}\})|\)(?!\}\}\}))*"
+
+(* Entities and LaTeX Fragments
+   https://orgmode.org/worg/dev/org-syntax.html#Entities_and_LaTeX_Fragments
+   https://orgmode.org/manual/LaTeX-fragments.html#LaTeX-fragments
+   https://orgmode.org/manual/LaTeX-fragments.html#LaTeX-fragments
+   The entity name must be in org-entities or org-entities-user. As
+   this is configurable, we parse any name that looks valid.
+
+   C-c C-x \ (org-toggle-pretty-entities)
+ *)
+text-entity = ""
+text-entity = <'\\'> entity-name ( entity-braces | ε & <#"[^a-zA-Z]|$"> )
+entity-name = #"[a-zA-Z]+"
+entity-braces = <'{}'>
 
 (* Hyperlinks (regular links)
    https://orgmode.org/guide/Hyperlinks.html

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -176,7 +176,7 @@ ts-mod-unit = #'[hdwmy]'
  *)
 
 (* TODO handle latex code? *)
-text = ( link-format / footnote-link / text-link / text-styled / text-normal )*
+text = ( link-format / footnote-link / text-link / text-styled / text-sub / text-sup / text-normal )*
 
 (* Emphasis and Monospace (font style markup)
    https://orgmode.org/manual/Emphasis-and-Monospace.html
@@ -205,8 +205,15 @@ text-link-normal = text-link-url
    This works because when parsing, text-normal is tried last.
    It can result in multiple subsequent text-normal which will be concated in a later transform step.
  *)
-text-normal = #".[^*/_=~+\[<]*"
+text-normal = #".[^*/_=~+\[<^]*"
 
+(* Superscript and subscript
+   https://orgmode.org/manual/Subscripts-and-Superscripts.html *)
+text-sub = <'_'> ( text-subsup-curly | text-subsup-word )
+text-sup = <'^'> ( text-subsup-curly | text-subsup-word )
+(* TODO word should match any unicode letter or digit but not "_" *)
+text-subsup-word = #"[a-zA-Z0-9]+"
+text-subsup-curly = <'{'> #"[^{}]*" <'}'>
 
 
 (* Hyperlinks

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -248,7 +248,7 @@ text-macro = <'{{{'> macro-name <'('> macro-args <')'> <'}}}'>
 macro-name = #"[a-zA-Z][-\w]*"
 macro-args = <''> | macro-arg ( <','> macro-arg )*
 (* "ARGUMENTS can contain anything but “}}}” string."
-   Comma must be escaped; ")" is only allowed when not followed by "}}}".
+   Comma must be escaped; ")" is only allowed when not followed by "}}}". *)
 <macro-arg> = #"(\\,|[^)},]|\}(?!\}\})|\)(?!\}\}\}))*"
 
 (* Entities and LaTeX Fragments

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -1,12 +1,14 @@
 S = line*
 
-<line> = (empty-line / head-line / affiliated-keyword-line / keyword-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-begin-line / drawer-end-line / list-item-line / footnote-line / content-line) eol
+<line> = (empty-line / head-line / affiliated-keyword-line / keyword-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-begin-line / drawer-end-line / list-item-line / footnote-line / literal-line / content-line) eol
 
 empty-line = "" | #"\s+"
 (* TODO same as title text below. *)
 content-line = #".*"
+(* content-line = text *)
 
 <eol> = <#'\n|$'>
+(* TODO remove <> to enable use where the spaces are actual needed *)
 <s> = <#"[\t ]+">
 <word> = #"[^\r\n\s$]+"
 
@@ -14,10 +16,16 @@ head-line = stars [s priority] [s comment-token] s title [s tags]
 stars = #'\*+'
 priority = <"[#"> #"[A-Z]" <"]">
 comment-token = <"COMMENT">
-(* TODO title text is more than just words; e.g. formatting and timestamps are allowed. -> generic text? *)
+(* TODO title text is more than just words; e.g. formatting and timestamps are allowed. *)
 title = !tags word {s !tags word}
 tags = <':'> ( tag <':'> )+
 <tag> = #'[a-zA-Z0-9_@#%]+'
+
+(* https://orgmode.org/manual/Literal-Examples.html *)
+(* TODO need to preserve leading space? *)
+literal-line = ll-leading-space <':'> ll-text
+ll-leading-space = #"[\t ]*"
+ll-text = #".*"
 
 affiliated-keyword-line = <"#+"> (key | attr) <": "> value
 optional = <"["> optional-value <"]">
@@ -55,6 +63,7 @@ footnote-line = <'['> footnote-label <'] '> footnote-contents
 footnote-label = (number | <'fn:'> footnote-word)
 <number> = #"\d+"
 <footnote-word> = #"[a-zA-Z0-9-_]+"
+(* TODO footnote-context should be text *)
 footnote-contents = anything-but-newline
 
 list-item-line = ( list-item-bullet | list-item-counter list-item-counter-suffix ) <" "> (list-item-checkbox <" "> list-item-contents / list-item-contents)
@@ -74,6 +83,7 @@ keyword-value = anything-but-newline
 node-property-line = <':'> node-property-name [node-property-plus] <':'> [<' '> node-property-value]
 node-property-name = #"[^\s:+]+"
 node-property-plus = <"+">
+(* TODO footnote-context should be text *)
 node-property-value = anything-but-newline
 
 
@@ -142,3 +152,33 @@ ts-warning-type  = ('-'|'--')
 
 ts-mod-value = #'\d+'
 ts-mod-unit = #'[hdwmy]'
+
+
+
+
+
+(* text is any orgmode text that can contain markup, links, footnotes, timestamps, ...
+
+   It can be a full line or part of a line (e.g. in title, lists, property values, tables, ...)
+
+ *)
+
+text = #".*" / link
+
+(* Hyperlinks
+   https://orgmode.org/guide/Hyperlinks.html
+ *)
+
+link = <'[['> link-uri <']]'> / <'[['> link-uri <']['> link-description <']]'>
+link-uri = #"[]]*"
+(* TODO do description must support markup? *)
+link-description = #"[]]*"
+
+(* External Links
+   https://orgmode.org/manual/External-Links.html
+   TODO reuse orgmode source/regexes?
+ *)
+
+(* Internal Links
+   https://orgmode.org/manual/Internal-Links.html
+ *)

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -218,9 +218,10 @@ text-normal = #".[^*/_=~+\[<]*"
 
  *)
 
-(* Any text inside link brackets [...] *)
-(* TODO link and description must support backslash escape for ], [, (and \) *)
-<link-inside> = #"[^]]*"
+(* Any text inside link brackets [[...][...]].
+   Backslash is the escape character for itself and opening/closing brackets.
+ *)
+<link-inside> = #"(\\\[|\\\]|\\\\|[^]\[])*"
 
 link-format = <'[['> link <']]'> / <'[['> link <']['> link-description <']]'>
 

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -228,11 +228,12 @@ text-link-plain-path = #"[^\s()<>]+(\w|[^\s[:punct:]]/)"
 text-normal = #".[^*/_=~+\[<^]*"
 
 (* Superscript and subscript
+   https://orgmode.org/worg/dev/org-syntax.html#Subscript_and_Superscript
    https://orgmode.org/manual/Subscripts-and-Superscripts.html *)
 text-sub = <'_'> ( text-subsup-curly | text-subsup-word )
 text-sup = <'^'> ( text-subsup-curly | text-subsup-word )
 (* TODO word should match any unicode letter or digit but not "_" *)
-text-subsup-word = #"[a-zA-Z0-9]+"
+text-subsup-word = #"\*|[+-]?[a-zA-Z0-9,.\\]*[a-zA-Z0-9]"
 text-subsup-curly = <'{'> #"[^{}]*" <'}'>
 
 (* https://orgmode.org/worg/dev/org-syntax.html#Targets_and_Radio_Targets *)

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -98,6 +98,8 @@ node-property-value = text
 
 (* timestamps
    https://orgmode.org/worg/dev/org-element-api.html
+   https://orgmode.org/worg/dev/org-syntax.html#Timestamp
+   https://orgmode.org/manual/Timestamps.html
 
    The symbol names are carefully chosen as a trade-off between
    shortness and consistency. They have a prefix, e.g. ts-mod-* for
@@ -114,13 +116,12 @@ node-property-value = text
    - e.g. values of :type, :repeater-type, :warning-type cannot be
      constructed with instaparse (to my understanding)
 
-   Currently not supported: diary format from the Emacs Calendar package
-   https://orgmode.org/manual/Timestamps.html
-
    *)
 
+timestamp = timestamp-diary / timestamp-active / timestamp-inactive
 
-timestamp = timestamp-active / timestamp-inactive
+timestamp-diary = <'<%%('> ts-diary-sexp <')>'>
+<ts-diary-sexp> = #"(\)(?!>)|[^)>\n])*"
 
 (* TODO How does that work out: :ts-inner appearing two times in :timestamp-active.
         And if it works in clojure, does it also work in JS hashes (parse result)? *)

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -1,3 +1,9 @@
+
+(* Main sources:
+   - Org Mode Manual: https://www.gnu.org/software/emacs/manual/html_mono/org.html
+   - Org Mode Compact Guide: https://orgmode.org/guide/
+*)
+
 S = line*
 
 <line> = (empty-line / head-line / affiliated-keyword-line / keyword-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-begin-line / drawer-end-line / list-item-line / footnote-line / literal-line / content-line) eol
@@ -168,9 +174,38 @@ ts-mod-unit = #'[hdwmy]'
 
  *)
 
-(* TODO footnote must come before link *)
-text = #".*" / link
+(* TODO handle latex code? *)
+(* TODO missing: footnotes; footnote must come before link *)
+text = ( link-format / text-link / text-styled / text-normal )*
 
+(* Emphasis and Monospace (font style markup)
+   https://orgmode.org/manual/Emphasis-and-Monospace.html
+   "Text in the code and verbatim string is not processed for Org specific syntax;"
+   Implies that the rest can be nested.
+ *)
+text-styled = text-sty-bold / text-sty-italic / text-sty-underlined / text-sty-verbatim / text-sty-code / text-sty-strikethrough
+
+(* TODO simplest possible solution; ignores ways of escaping and does not allow the delim to appear inside *)
+text-sty-bold          = <'*'> #"[^*]+" <'*'>
+text-sty-italic        = <'/'> #"[^/]+" <'/'>
+text-sty-underlined    = <'_'> #"[^_]+" <'_'>
+text-sty-verbatim      = <'='> #"[^=]+" <'='>
+text-sty-code          = <'~'> #"[^~]+" <'~'>
+text-sty-strikethrough = <'+'> #"[^+]+" <'+'>
+
+(* TODO compare with org mode regexes; support more protocols *)
+text-link = text-link-angled / text-link-normal
+text-link-angled = <'<'> text-link-url <'>'>
+text-link-normal = text-link-url
+<text-link-url> = #"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)"
+(* regex taken from: https://stackoverflow.com/a/3809435 *)
+
+(* TODO how to prevent greedyness? e.g. not parse text-link-normal (-> look-ahead?) *)
+(* Simple work-around: parse characters as long there are no style delimiters – but always parse one character.
+   This works because when parsing, text-normal is tried last.
+   It can result in multiple subsequent text-normal which will be concated in a later transform step.
+ *)
+text-normal = #".[^*/_=~+\[<]*"
 
 
 
@@ -189,7 +224,7 @@ text = #".*" / link
 
 link-format = <'[['> link <']]'> / <'[['> link <']['> link-description <']]'>
 
-(* > If the link does not look like a URL, it is considered to be internal in the current file.
+(* "If the link does not look like a URL, it is considered to be internal in the current file."
    - from orgmode guide. Hence the ordered alternatives: *)
 link = link-ext / link-int
 (* TODO does description must support markup? *)

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -179,7 +179,7 @@ ts-mod-unit = #'[hdwmy]'
  *)
 
 (* TODO handle latex code? *)
-text = ( link-format / footnote-link / text-link / text-target / text-radio-target / text-entity / text-macro / text-styled / text-sub / text-sup / text-normal )*
+text = ( link-format / footnote-link / text-link / text-target / text-radio-target / text-entity / text-macro / text-styled / text-sub / text-sup / text-linebreak / text-normal )*
 
 (* Emphasis and Monospace (font style markup)
    https://orgmode.org/manual/Emphasis-and-Monospace.html
@@ -270,6 +270,9 @@ text-entity = ""
 text-entity = <'\\'> entity-name ( entity-braces | ε & <#"[^a-zA-Z]|$"> )
 entity-name = #"[a-zA-Z]+"
 entity-braces = <'{}'>
+
+text-linebreak = <'\\\\'> text-linebreak-after
+text-linebreak-after = #"\s*$"
 
 (* Hyperlinks (regular links)
    https://orgmode.org/guide/Hyperlinks.html

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -412,13 +412,22 @@ is another section"))))))
 
 
 (deftest literal-line
-  (let [parse #(parser/org % :start :literal-line)]
-    (testing "parse literal line starting with colon"
-      (is (= [:literal-line [:ll-leading-space ""] [:ll-text "literal text"]]
-             (parse ":literal text"))))
-    (testing "parse literal line starting with spaces"
-      (is (= [:literal-line [:ll-leading-space "  "] [:ll-text " literal text "]]
-             (parse "  : literal text "))))))
+  (let [parse #(parser/org % :start :fixed-width-line)]
+    (testing "parse fixed-width line starting with colon"
+      (is (= [:fixed-width-line [:fw-head ":"] [:fw-rest " "]]
+             (parse ": "))))
+    (testing "parse fixed-width line starting with colon"
+      (is (= [:fixed-width-line [:fw-head ":"] [:fw-rest ""]]
+             (parse ":"))))
+    (testing "parse fixed-width line starting with colon"
+      (is (= [:fixed-width-line [:fw-head ":"] [:fw-rest " literal text"]]
+             (parse ": literal text"))))
+    (testing "parse fixed-width line starting with spaces"
+      (is (= [:fixed-width-line [:fw-head "  :"] [:fw-rest " literal text "]]
+             (parse "  : literal text "))))
+    (testing "parse fixed-width line starting with colon"
+      (is (insta/failure? (parse ":literal text"))))
+    ))
 
 (deftest links
   (let [parse #(parser/org % :start :link-format)]

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -660,6 +660,13 @@ is another section"))))))
               [:text-sub [:text-subsup-curly "123"]]]
              (parse "text^abc_{123}"))))
 
+    ;; macros
+    (testing "parse macro"
+      (is (= [:text [:text-normal "text"] [:text-macro
+                                           [:macro-name "my_macro5"]
+                                           [:macro-args "0" "'{abc}'"]]]
+             (parse "text{{{my_macro5(0,'{abc}')}}}"))))
+
     ;; targets and radio targets
     (testing "parse target"
       (is (= [:text [:text-normal "text"] [:text-target [:text-target-name "my target"]]]
@@ -669,6 +676,19 @@ is another section"))))))
              (parse "text<<<my target>>>"))))
     ))
 
+
+(deftest text-macros
+  (let [parse #(parser/org % :start :text-macro)]
+    (testing "parse macro without args"
+      (is (= [:text-macro [:macro-name "my_macro5"] [:macro-args ""]]
+             (parse "{{{my_macro5()}}}"))))
+    (testing "parse macro with arg"
+      (is (= [:text-macro [:macro-name "my_macro5"] [:macro-args "arg"]]
+             (parse "{{{my_macro5(arg)}}}"))))
+    (testing "parse macro"
+      (is (= [:text-macro [:macro-name "my_macro5"] [:macro-args "x\\,y" " (0)", "'{abc}'"]]
+             (parse "{{{my_macro5(x\\,y, (0),'{abc}')}}}"))))
+    ))
 
 (deftest text-targets
   (let [parse #(parser/org % :start :text-target)]

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -450,6 +450,9 @@ is another section"))))))
     (testing "parse file link"
       (is (= [:link-ext-file "~/folder/file.txt"]
              (parse "file:~/folder/file.txt"))))
+    (testing "parse file link containing single colons"
+      (is (= [:link-ext-file "~/fol:der/fi:le.txt"]
+             (parse "file:~/fol:der/fi:le.txt"))))
     (testing "parse relative file link"
       (is (= [:link-ext-file "./folder/file.txt"]
              (parse "./folder/file.txt"))))
@@ -462,6 +465,10 @@ is another section"))))))
     (testing "parse file link with text search string"
       (is (= [:link-ext-file "./file.org" [:link-file-loc-string "foo bar"]]
              (parse "./file.org::foo bar"))))
+    (testing "parse file link with text search string containing ::"
+      ;; this matches orgmode behavior
+      (is (= [:link-ext-file "./file.org" [:link-file-loc-string "foo::bar"]]
+             (parse "./file.org::foo::bar"))))
     (testing "parse file link with headline"
       (is (= [:link-ext-file "./file.org" [:link-file-loc-headline "header1: test"]]
              (parse "./file.org::*header1: test"))))

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -388,7 +388,16 @@ is another section"))))))
 	      [:link-url-scheme "https"]
 	      [:link-url-rest "//example.com"]]]]
 	     [:link-description "description words"]]
-             (parse "[[https://example.com][description words]]"))))))
+             (parse "[[https://example.com][description words]]"))))
+    (testing "parse interal * link"
+      (is (= [:link-format [:link [:link-int [:link-file-loc-customid "my-custom-id"]]]]
+             (parse "[[#my-custom-id]]"))))
+    (testing "parse interal # link"
+      (is (= [:link-format [:link [:link-int [:link-file-loc-headline "My Header"]]]]
+             (parse "[[*My Header]]"))))
+    (testing "parse interal link"
+      (is (= [:link-format [:link [:link-int [:link-file-loc-string "A Name"]]]]
+             (parse "[[A Name]]"))))))
 
 (deftest links-external-file
   (let [parse #(parser/org % :start :link-ext-file)]

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -537,6 +537,9 @@ is another section"))))))
     (testing "parse strike-through text"
       (is (= [:text-styled [:text-sty-strikethrough [:text [:text-normal "strike-through text"]]]]
              (parse "+strike-through text+"))))
+    ;; parse reluctant
+    (testing "parse text-styled alone is not reluctant"
+      (is (not (insta/failure? (parse "/italic/ italic/")))))
     ))
 
 (deftest text-link
@@ -551,9 +554,18 @@ is another section"))))))
 
 (deftest text
   (let [parse #(parser/org % :start :text)]
+    (testing "parse text that contains style delimiter"
+      (is (= [:text [:text-normal "a"] [:text-normal "/b"]]
+             (parse "a/b"))))
+    (testing "parse text that contains style delimiter"
+      (is (= [:text [:text-normal "a "] [:text-normal "/b"]]
+             (parse "a /b"))))
     (testing "parse styled text alone"
       (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]]
              (parse "*bold text*"))))
+    (testing "if given multi-line text, parse bold text" ;; normally, parsing text is line-based
+      (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "a\nb"]]]]]
+             (parse "*a\nb*"))))
     (testing "parse styled text followed by normal text"
       (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]
               [:text-normal " normal text"]]
@@ -568,6 +580,11 @@ is another section"))))))
               [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]
               [:text-normal " more text"]]
              (parse "normal text *bold text* more text"))))
+    (testing "parse styled text reluctant"
+      (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]
+              [:text-normal " text"]
+              [:text-normal "*"]]
+             (parse "*bold text* text*"))))
     (testing "parse angled text link surrounded by normal text"
       (is (= [:text
               [:text-normal "normal text "]

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -674,6 +674,19 @@ is another section"))))))
     (testing "parse radio target"
       (is (= [:text [:text-normal "text"] [:text-radio-target [:text-target-name "my target"]]]
              (parse "text<<<my target>>>"))))
+
+    ;; entities
+    (testing "parse entity"
+      (is (= [:text [:text-normal "text"]
+              [:text-entity [:entity-name "Alpha"]]
+              [:text-normal "-followed"]]
+             (parse "text\\Alpha-followed"))))
+    (testing "parse entity"
+      (is (= [:text [:text-normal "text "]
+              [:text-entity [:entity-name "Alpha"] [:entity-braces]]
+              [:text-normal "followed"]]
+             (parse "text \\Alpha{}followed"))))
+
     ))
 
 
@@ -688,6 +701,16 @@ is another section"))))))
     (testing "parse macro"
       (is (= [:text-macro [:macro-name "my_macro5"] [:macro-args "x\\,y" " (0)", "'{abc}'"]]
              (parse "{{{my_macro5(x\\,y, (0),'{abc}')}}}"))))
+    ))
+
+(deftest text-entities
+  (let [parse #(parser/org % :start :text-entity)]
+    (testing "parse entity"
+      (is (= [:text-entity [:entity-name "Alpha"]]
+             (parse "\\Alpha"))))
+    (testing "parse entity"
+      (is (= [:text-entity [:entity-name "Alpha"] [:entity-braces]]
+             (parse "\\Alpha{}"))))
     ))
 
 (deftest text-targets

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -262,13 +262,13 @@ is another section"))))))
     (testing "node-property"
       (is (= [:node-property-line
               [:node-property-name "HELLO"]
-              [:node-property-value "hello world"]]
+              [:node-property-value [:text [:text-normal "hello world"]]]]
              (parse ":HELLO: hello world"))))
     (testing "node-property"
       (is (= [:node-property-line
               [:node-property-name "HELLO"]
               [:node-property-plus]
-              [:node-property-value "hello world"]]
+              [:node-property-value [:text [:text-normal "hello world"]]]]
              (parse ":HELLO+: hello world"))))
     ))
 

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -411,13 +411,13 @@ is another section"))))))
 	      [:link-url-rest "//example.com"]]]]
 	     [:link-description "description words"]]
              (parse "[[https://example.com][description words]]"))))
-    (testing "parse interal * link"
+    (testing "parse internal * link"
       (is (= [:link-format [:link [:link-int [:link-file-loc-customid "my-custom-id"]]]]
              (parse "[[#my-custom-id]]"))))
-    (testing "parse interal # link"
+    (testing "parse internal # link"
       (is (= [:link-format [:link [:link-int [:link-file-loc-headline "My Header"]]]]
              (parse "[[*My Header]]"))))
-    (testing "parse interal link"
+    (testing "parse internal link"
       (is (= [:link-format [:link [:link-int [:link-file-loc-string "A Name"]]]]
              (parse "[[A Name]]"))))))
 

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -545,10 +545,14 @@ is another section"))))))
 (deftest text-link
   (let [parse #(parser/org % :start :text-link)]
     (testing "parse angled link"
-      (is (= [:text-link [:text-link-angled "http://example.com/foo?bar=baz&baz=bar"]]
+      (is (= [:text-link [:text-link-angle
+                          [:link-url-scheme "http"]
+                          [:text-link-angle-path "//example.com/foo?bar=baz&baz=bar"]]]
              (parse "<http://example.com/foo?bar=baz&baz=bar>"))))
-    (testing "parse normal link"
-      (is (= [:text-link [:text-link-normal "http://example.com/foo?bar=baz&baz=bar"]]
+    (testing "parse plain link"
+      (is (= [:text-link [:text-link-plain
+                          [:link-url-scheme "http"]
+                          [:text-link-plain-path "//example.com/foo?bar=baz&baz=bar"]]]
              (parse "http://example.com/foo?bar=baz&baz=bar"))))
     ))
 
@@ -588,13 +592,15 @@ is another section"))))))
     (testing "parse angled text link surrounded by normal text"
       (is (= [:text
               [:text-normal "normal text "]
-              [:text-link [:text-link-angled "http://example.com"]]
+              [:text-link [:text-link-angle
+                           [:link-url-scheme "http"]
+                           [:text-link-angle-path "//example.com"]]]
               [:text-normal " more text"]]
              (parse "normal text <http://example.com> more text"))))
     ;; TODO (testing "parse normal text link surrounded by normal text"
     ;;   (is (= [:text
     ;;           [:text-normal "normal text "]
-    ;;           [:text-link [:text-link-normal "http://example.com"]]
+    ;;           [:text-link [:text-link-plain "http://example.com"]]
     ;;           [:text-normal " more text"]]
     ;;          (parse "normal text http://example.com more text"))))
     (testing "parse link surrounded by normal text"

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -445,6 +445,9 @@ is another section"))))))
 	      [:link-url-rest "//example.com"]]]]
 	     [:link-description "description words"]]
              (parse "[[https://example.com][description words]]"))))
+    (testing "parse id link"
+      (is (= [:link-format [:link [:link-ext [:link-ext-id "abc-123"]]]]
+             (parse "[[id:abc-123]]"))))
     (testing "parse internal * link"
       (is (= [:link-format [:link [:link-int [:link-file-loc-customid "my-custom-id"]]]]
              (parse "[[#my-custom-id]]"))))
@@ -453,7 +456,16 @@ is another section"))))))
              (parse "[[*My Header]]"))))
     (testing "parse internal link"
       (is (= [:link-format [:link [:link-int [:link-file-loc-string "A Name"]]]]
-             (parse "[[A Name]]"))))))
+             (parse "[[A Name]]"))))
+    ))
+
+(deftest id-links
+  (let [parse #(parser/org % :start :link-ext-id)]
+    (testing "invalid id link"
+      (is (insta/failure? (parse "[[id:]]"))))
+    (testing "invalid id link"
+      (is (insta/failure? (parse "[[id:z]]"))))
+    ))
 
 (deftest links-with-escapse
   (let [parse #(parser/org % :start :link-format)]

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -589,6 +589,11 @@ is another section"))))))
               [:text-normal " text"]
               [:text-normal "*"]]
              (parse "*bold text* text*"))))
+    ;; TODO parse only when "surrounded" by delimiter
+    ;; (testing "parse italic text"
+    ;;   (is (= [:text [:text-styled [:text-sty-italic
+    ;;                         [:text [:text-normal "italic "] [:text-normal "/ text"]]]]]
+    ;;          (parse "/italic / text/"))))
     (testing "parse angled text link surrounded by normal text"
       (is (= [:text
               [:text-normal "normal text "]
@@ -618,6 +623,10 @@ is another section"))))))
 	       [:link-url-rest "//example.com"]]]]]
 	      [:footnote-link "reserved"]]
              (parse "normal text [[http://example.com]][fn::reserved]"))))
+    ;; TODO this is not a subscript (space before)
+    ;; (testing "parse non-subscript"
+    ;;   (is (= [:text [:text-normal "text _abc"]]
+    ;;          (parse "text _abc"))))
     (testing "parse subscript"
       (is (= [:text [:text-normal "text"] [:text-sub [:text-subsup-word "abc"]]]
              (parse "text_abc"))))

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -361,7 +361,29 @@ is another section"))))))
 
     (testing "newlines are not recognized as space \\s"
       ;; http://xahlee.info/clojure/clojure_instaparse.html
-      (is (insta/failure? (parse "<2020-04-17 F\nri>"))))))
+      (is (insta/failure? (parse "<2020-04-17 F\nri>"))))
+    (testing "newlines are not recognized as space"
+      ;; http://xahlee.info/clojure/clojure_instaparse.html
+      (is (insta/failure? (parse "<2020-04-17\nFri>"))))))
+
+(deftest timestamp
+  (let [parse #(parser/org % :start :ts-time)]
+    (testing "parse time"
+      (is (= [:ts-time "08:00"]
+             (parse "08:00"))))
+    (testing "parse time without leading zero"
+      (is (= [:ts-time "8:00"]
+             (parse "8:00"))))
+    (testing "parse time with seconds"
+      (is (= [:ts-time "08:00:00"]
+             (parse "08:00:00"))))
+    (testing "parse time a.m."
+      (is (= [:ts-time "8:00AM"]
+             (parse "8:00AM"))))
+    (testing "parse time p.m."
+      (is (= [:ts-time "08:00pm"]
+             (parse "08:00pm"))))))
+
 
 
 (deftest literal-line

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -562,8 +562,27 @@ is another section"))))))
       (is (= [:text-styled [:text-sty-strikethrough [:text [:text-normal "strike-through text"]]]]
              (parse "+strike-through text+"))))
     ;; parse reluctant
-    (testing "parse text-styled alone is not reluctant"
-      (is (not (insta/failure? (parse "/italic/ italic/")))))
+    ;; (testing "parse text-styled alone is not reluctant"
+    ;;   (is (not (insta/failure? (parse "/italic/ italic/")))))
+    (testing "parse verbatim text reluctantly"
+      (is (insta/failure? (parse "=verbatim= text="))))
+
+    ;; parse special cases
+    (testing "not parse empty verbatim text"
+      (is (insta/failure? (parse "=="))))
+    (testing "not parse verbatim text with space around"
+      (is (insta/failure? (parse "=verbatim ="))))
+    (testing "not parse verbatim text with space around"
+      (is (insta/failure? (parse "= verbatim="))))
+    (testing "parse verbatim text"
+      (is (= [:text-styled [:text-sty-verbatim "verbatim = text"]]
+             (parse "=verbatim = text="))))
+    (testing "parse verbatim text"
+      (is (= [:text-styled [:text-sty-verbatim "="]]
+             (parse "==="))))
+    (testing "parse verbatim text"
+      (is (= [:text-styled [:text-sty-verbatim "a"]]
+             (parse "=a="))))
     ))
 
 (deftest text-link

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -663,6 +663,14 @@ is another section"))))))
               [:text-sub [:text-subsup-curly "123"]]]
              (parse "text^abc_{123}"))))
 
+    ;; line breaks
+    (testing "parse text followed by line break"
+      (is (= [:text [:text-normal "abc "] [:text-linebreak [:text-linebreak-after "  "]]]
+             (parse "abc \\\\  "))))
+    (testing "parse text followed by line break"
+      (is (= [:text [:text-normal "abc "] [:text-normal "\\"] [:text-normal "\\ xyz"]]
+             (parse "abc \\\\ xyz"))))
+
     ;; macros
     (testing "parse macro"
       (is (= [:text [:text-normal "text"] [:text-macro

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -667,6 +667,7 @@ is another section"))))))
 
 (deftest text-subscript
   (let [parse #(parser/org % :start :text-sub)]
+    ;; TODO make sure preceeding character is non-whitespace
     (testing "parse subscript word"
       (is (= [:text-sub [:text-subsup-word "abc"]]
              (parse "_abc"))))
@@ -676,6 +677,18 @@ is another section"))))))
     (testing "parse subscript word/number mixed"
       (is (= [:text-sub [:text-subsup-word "1a2b"]]
              (parse "_1a2b"))))
+    (testing "parse subscript star"
+      (is (= [:text-sub [:text-subsup-word "*"]]
+             (parse "_*"))))
+    (testing "parse subscript special"
+      (is (= [:text-sub [:text-subsup-word ".,\\a"]]
+             (parse "_.,\\a"))))
+    (testing "parse subscript special"
+      (is (= [:text-sub [:text-subsup-word "-.,\\a"]]
+             (parse "_-.,\\a"))))
+    (testing "parse subscript special"
+      (is (= [:text-sub [:text-subsup-word "+.,\\a"]]
+             (parse "_+.,\\a"))))
     (testing "parse subscript in curly braces"
       (is (= [:text-sub [:text-subsup-curly ".,-123abc!"]]
              (parse "_{.,-123abc!}"))))

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -638,6 +638,31 @@ is another section"))))))
               [:text-sup [:text-subsup-word "abc"]]
               [:text-sub [:text-subsup-curly "123"]]]
              (parse "text^abc_{123}"))))
+
+    ;; targets and radio targets
+    (testing "parse target"
+      (is (= [:text [:text-normal "text"] [:text-target [:text-target-name "my target"]]]
+             (parse "text<<my target>>"))))
+    (testing "parse radio target"
+      (is (= [:text [:text-normal "text"] [:text-radio-target [:text-target-name "my target"]]]
+             (parse "text<<<my target>>>"))))
+    ))
+
+
+(deftest text-targets
+  (let [parse #(parser/org % :start :text-target)]
+    (testing "parse target"
+      (is (= [:text-target [:text-target-name "t"]]
+             (parse "<<t>>"))))
+    (testing "parse invalid target"
+      (is (insta/failure?
+             (parse "<< t>>"))))
+    (testing "parse invalid target"
+      (is (insta/failure?
+             (parse "<<t >>"))))
+    (testing "parse invalid target"
+      (is (insta/failure?
+             (parse "<< >>"))))
     ))
 
 (deftest text-subscript

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -402,8 +402,8 @@ is another section"))))))
 	      [:link-url-scheme "https"]
 	      [:link-url-rest "//example.com"]]]]]
              (parse "[[https://example.com]]"))))
-    (testing "parse simple link without protocol"
-      (is (= [:link-format [:link [:link-ext [:link-ext-web "www.example.com"]]]]
+    (testing "parse simple link that looks like an web address but is not valid"
+      (is (= [:link-format [:link [:link-int [:link-file-loc-string "www.example.com"]]]]
              (parse "[[www.example.com]]"))))
     (testing "parse link with description"
       (is (= [:link-format [:link [:link-ext [:link-ext-other
@@ -471,6 +471,8 @@ is another section"))))))
 
 (deftest links-external-other-url
   (let [parse #(parser/org % :start :link-ext-other)]
+    (testing "parse simple link that looks like an web address but is not valid"
+      (is (insta/failure? (parse "www.example.com"))))
     (testing "parse other http link"
       (is (= [:link-ext-other [:link-url-scheme "https"] [:link-url-rest "//example.com"]]
              (parse "https://example.com"))))
@@ -480,19 +482,6 @@ is another section"))))))
     (testing "parse other link with uncommon scheme"
       (is (= [:link-ext-other [:link-url-scheme "zyx"] [:link-url-rest "rest-of uri ..."]]
              (parse "zyx:rest-of uri ..."))))))
-
-(deftest links-external-web-address
-  (let [parse #(parser/org % :start :link-ext-web)]
-    (testing "parse web address without scheme"
-      (is (= [:link-ext-web "www.example.com"]
-             (parse "www.example.com"))))
-    (testing "parse web address without scheme"
-      (is (= [:link-ext-web "a.subdomain.example.com"]
-             (parse "a.subdomain.example.com"))))
-    (testing "parse web address without scheme"
-      (is (= [:link-ext-web "example.com/list?filter=abc&sort=Desc"]
-             (parse "example.com/list?filter=abc&sort=Desc"))))))
-
 
 
 

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -274,6 +274,9 @@ is another section"))))))
 
 (deftest timestamp
   (let [parse #(parser/org % :start :timestamp)]
+    (testing "diary timestamp"
+      (is (= [:timestamp [:timestamp-diary ""]]
+             (parse "<%%(( <(sexp)().))>"))))
     (testing "date timestamp without day"
       (is (= [:timestamp [:timestamp-active [:ts-inner [:ts-inner-wo-time [:ts-date "2020-01-18"]] [:ts-modifiers]]]]
              (parse "<2020-01-18>"))))

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -421,6 +421,27 @@ is another section"))))))
       (is (= [:link-format [:link [:link-int [:link-file-loc-string "A Name"]]]]
              (parse "[[A Name]]"))))))
 
+(deftest links-with-escapse
+  (let [parse #(parser/org % :start :link-format)]
+    ;; remember that "\\" is one backslash!
+    (testing "parse link with just one literal backslash"
+      (is (insta/failure? (parse "[[\\]]"))))
+    (testing "parse link with escaped backslash"
+      (is (= [:link-format [:link [:link-int [:link-file-loc-string "\\\\"]]]]
+             (parse "[[\\\\]]"))))
+    (testing "parse link with unescaped backslash"
+      (is (= [:link-format [:link [:link-int [:link-file-loc-string "\\a"]]]]
+             (parse "[[\\a]]"))))
+    (testing "parse link with unescaped opening bracket"
+      (is (insta/failure? (parse "[[a[b]]"))))
+    (testing "parse link with escaped opening bracket"
+      (is (= [:link-format [:link [:link-int [:link-file-loc-string "\\["]]]]
+             (parse "[[\\[]]"))))
+    (testing "parse link with escaped closing bracket"
+      (is (= [:link-format [:link [:link-int [:link-file-loc-string "\\]"]]]]
+             (parse "[[\\]]]"))))
+    ))
+
 (deftest links-external-file
   (let [parse #(parser/org % :start :link-ext-file)]
     (testing "parse file link"

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -612,4 +612,33 @@ is another section"))))))
 	       [:link-url-rest "//example.com"]]]]]
 	      [:footnote-link "reserved"]]
              (parse "normal text [[http://example.com]][fn::reserved]"))))
+    (testing "parse subscript"
+      (is (= [:text [:text-normal "text"] [:text-sub [:text-subsup-word "abc"]]]
+             (parse "text_abc"))))
+    (testing "parse superscript"
+      (is (= [:text [:text-normal "text"] [:text-sup [:text-subsup-word "123"]]]
+             (parse "text^123"))))
+    (testing "parse sub- and superscript"
+      (is (= [:text [:text-normal "text"]
+              [:text-sup [:text-subsup-word "abc"]]
+              [:text-sub [:text-subsup-curly "123"]]]
+             (parse "text^abc_{123}"))))
+    ))
+
+(deftest text-subscript
+  (let [parse #(parser/org % :start :text-sub)]
+    (testing "parse subscript word"
+      (is (= [:text-sub [:text-subsup-word "abc"]]
+             (parse "_abc"))))
+    (testing "parse subscript number"
+      (is (= [:text-sub [:text-subsup-word "123"]]
+             (parse "_123"))))
+    (testing "parse subscript word/number mixed"
+      (is (= [:text-sub [:text-subsup-word "1a2b"]]
+             (parse "_1a2b"))))
+    (testing "parse subscript in curly braces"
+      (is (= [:text-sub [:text-subsup-curly ".,-123abc!"]]
+             (parse "_{.,-123abc!}"))))
+    (testing "curly braces inside braced subscript are not allowed"
+      (is (insta/failure? (parse "text_{{}"))))
     ))

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -523,10 +523,12 @@ is another section"))))))
       (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]]
              (parse "*bold text*"))))
     (testing "parse styled text followed by normal text"
-      (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]] [:text-normal " normal text"]]
+      (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]
+              [:text-normal " normal text"]]
              (parse "*bold text* normal text"))))
     (testing "parse normal text followed by styled text"
-      (is (= [:text [:text-normal "normal text "] [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]]
+      (is (= [:text [:text-normal "normal text "]
+              [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]]
              (parse "normal text *bold text*"))))
     (testing "parse styled text surrounded by normal text"
       (is (= [:text

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -499,22 +499,22 @@ is another section"))))))
 (deftest text-styled
   (let [parse #(parser/org % :start :text-styled)]
     (testing "parse bold text"
-      (is (= [:text-styled [:text-sty-bold "bold text"]]
+      (is (= [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]
              (parse "*bold text*"))))
     (testing "parse italic text"
-      (is (= [:text-styled [:text-sty-italic "italic text"]]
+      (is (= [:text-styled [:text-sty-italic [:text [:text-normal "italic text"]]]]
              (parse "/italic text/"))))
     (testing "parse underlined text"
-      (is (= [:text-styled [:text-sty-underlined "underlined text"]]
+      (is (= [:text-styled [:text-sty-underlined [:text [:text-normal "underlined text"]]]]
              (parse "_underlined text_"))))
     (testing "parse verbatim text"
-      (is (= [:text-styled [:text-sty-verbatim "verbatim text"]]
-             (parse "=verbatim text="))))
+      (is (= [:text-styled [:text-sty-verbatim "verbatim /abc/ text"]]
+             (parse "=verbatim /abc/ text="))))
     (testing "parse code text"
-      (is (= [:text-styled [:text-sty-code "code text"]]
-             (parse "~code text~"))))
+      (is (= [:text-styled [:text-sty-code "code *abc* text"]]
+             (parse "~code *abc* text~"))))
     (testing "parse strike-through text"
-      (is (= [:text-styled [:text-sty-strikethrough "strike-through text"]]
+      (is (= [:text-styled [:text-sty-strikethrough [:text [:text-normal "strike-through text"]]]]
              (parse "+strike-through text+"))))
     ))
 
@@ -531,18 +531,18 @@ is another section"))))))
 (deftest text
   (let [parse #(parser/org % :start :text)]
     (testing "parse styled text alone"
-      (is (= [:text [:text-styled [:text-sty-bold "bold text"]]]
+      (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]]
              (parse "*bold text*"))))
     (testing "parse styled text followed by normal text"
-      (is (= [:text [:text-styled [:text-sty-bold "bold text"]] [:text-normal " normal text"]]
+      (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]] [:text-normal " normal text"]]
              (parse "*bold text* normal text"))))
     (testing "parse normal text followed by styled text"
-      (is (= [:text [:text-normal "normal text "] [:text-styled [:text-sty-bold "bold text"]]]
+      (is (= [:text [:text-normal "normal text "] [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]]
              (parse "normal text *bold text*"))))
     (testing "parse styled text surrounded by normal text"
       (is (= [:text
               [:text-normal "normal text "]
-              [:text-styled [:text-sty-bold "bold text"]]
+              [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]
               [:text-normal " more text"]]
              (parse "normal text *bold text* more text"))))
     (testing "parse angled text link surrounded by normal text"

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -362,3 +362,13 @@ is another section"))))))
     (testing "newlines are not recognized as space \\s"
       ;; http://xahlee.info/clojure/clojure_instaparse.html
       (is (insta/failure? (parse "<2020-04-17 F\nri>"))))))
+
+
+(deftest literal-line
+  (let [parse #(parser/org % :start :literal-line)]
+    (testing "parse literal line starting with colon"
+      (is (= [:literal-line [:ll-leading-space ""] [:ll-text "literal text"]]
+             (parse ":literal text"))))
+    (testing "parse literal line starting with spaces"
+      (is (= [:literal-line [:ll-leading-space "  "] [:ll-text " literal text "]]
+             (parse "  : literal text "))))))


### PR DESCRIPTION
text is any orgmode text that can contain **style, links, footnotes, timestamps, ...**

It can be a full line or part of a line (e.g. in title, lists, property values, tables, ...)
