### PR TITLE
Try parsing semantic elements instead of line-based

### DIFF
--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -7,12 +7,18 @@
 
 S = line*
 
-<line> = (empty-line / headline / affiliated-keyword-line / keyword-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-end-line / drawer-begin-line / list-item-line / footnote-line / fixed-width-line / horizontal-rule / content-line) eol
+<line> = (empty-line / headline / affiliated-keyword-line / keyword-line / comment-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-end-line / drawer-begin-line / list-item-line / footnote-line / fixed-width-line / horizontal-rule / content-line) eol
 
 empty-line = "" | #"\s+"
 (* TODO same as title text below. *)
 content-line = #".*"
 (* content-line = text *)
+
+(* "Comments consist of one or more consecutive comment lines."
+   https://orgmode.org/worg/dev/org-syntax.html#Comments *)
+comment-line = comment-line-head comment-line-rest
+comment-line-head = #"\s*#(?= |$)"
+comment-line-rest = #".*"
 
 <eol> = <#'\n|$'>
 (* TODO remove <> to enable use where the spaces are actual needed *)

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -152,7 +152,9 @@ keyword-line = <'#+'> keyword-key <':'> [<' '> keyword-value]
 keyword-key = #"[^\s:]+"
 keyword-value = anything-but-newline
 
-node-property-line = <':'> node-property-name [node-property-plus] <':'> [<' '> node-property-value] <eol>
+(* TODO allow empty properties with or without trailing space *)
+(* TODO looks like node-property-line also parses :END: *)
+node-property-line = ! <':END:> <':'> node-property-name [node-property-plus] <':'> ( <' '> node-property-value | [<' '>] ) <eol>
 node-property-name = #"[^\s:+]+"
 node-property-plus = <"+">
 node-property-value = text

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -7,7 +7,7 @@
 
 S = line*
 
-<line> = (empty-line / headline / affiliated-keyword-line / keyword-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-end-line / drawer-begin-line / list-item-line / footnote-line / fixed-width-line / content-line) eol
+<line> = (empty-line / headline / affiliated-keyword-line / keyword-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-end-line / drawer-begin-line / list-item-line / footnote-line / fixed-width-line / horizontal-rule / content-line) eol
 
 empty-line = "" | #"\s+"
 (* TODO same as title text below. *)
@@ -43,6 +43,9 @@ value = #"[^\]\n]+"
 key = "HEADER" | "NAME" | "PLOT" | (("RESULTS" | "CAPTION") [ optional ]) | "AUTHOR" | "DATE" | "TITLE"
 attr = <"ATTR_"> backend
 backend = #"[a-zA-Z0-9-_]+"
+
+(* https://orgmode.org/worg/dev/org-syntax.html#Horizontal_Rules *)
+horizontal-rule = #"\s*-----+"
 
 (* TODO add equivalent TODO keyword specifiers
         and allow more than [A-Z] in todo keyword names, esp. the shorthand definitions(d)

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -7,7 +7,7 @@
 
 S = line*
 
-<line> = (empty-line / head-line / affiliated-keyword-line / keyword-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-end-line / drawer-begin-line / list-item-line / footnote-line / fixed-width-line / content-line) eol
+<line> = (empty-line / headline / affiliated-keyword-line / keyword-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-end-line / drawer-begin-line / list-item-line / footnote-line / fixed-width-line / content-line) eol
 
 empty-line = "" | #"\s+"
 (* TODO same as title text below. *)
@@ -19,8 +19,9 @@ content-line = #".*"
 <s> = <#"[\t ]+">
 <word> = #"[^\r\n\s$]+"
 
-head-line = stars [s priority] [s comment-token] s title [s tags]
+headline = stars [s keyword] [s priority] [s comment-token] s title [s tags]
 stars = #'\*+'
+keyword = #"[A-Z]+"
 priority = <"[#"> #"[A-Z]" <"]">
 comment-token = <"COMMENT">
 (* TODO title text is more than just words; e.g. formatting and timestamps are allowed. *)

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -154,7 +154,7 @@ keyword-value = anything-but-newline
 
 (* TODO allow empty properties with or without trailing space *)
 (* TODO looks like node-property-line also parses :END: *)
-node-property-line = ! <':END:> <':'> node-property-name [node-property-plus] <':'> ( <' '> node-property-value | [<' '>] ) <eol>
+node-property-line = ! <':END:'> <':'> node-property-name [node-property-plus] <':'> ( <' '> node-property-value | [<' '>] ) <eol>
 node-property-name = #"[^\s:+]+"
 node-property-plus = <"+">
 node-property-value = text

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -23,7 +23,7 @@ comment-line-rest = #".*"
 <eol> = <#'\n|$'>
 (* TODO remove <> to enable use where the spaces are actual needed *)
 <s> = <#"[\t ]+">
-<word> = #"[^\r\n\s$]+"
+<word> = #"[^\r\n\s]+"
 
 headline = stars [s keyword] [s priority] [s comment-token] s title [s tags]
 stars = #'\*+'
@@ -61,24 +61,64 @@ todo-line = <"#+TODO: "> states
 todo-state = #"[A-Z]+"
 done-state = #"[A-Z]+"
 
-greater-block-begin-line = <"#+BEGIN_"> greater-block-name [s greater-block-parameters]
-greater-block-name = anything-but-whitespace
+(* TODO blocks - see greater-block for why this is faulty *)
+block = block-noparse | greater-block
+
+(* Greater Blocks - can contain Blocks
+   https://orgmode.org/worg/dev/org-syntax.html#Greater_Blocks
+
+   TODO currently blocks have many problems:
+   - content is parsed greedy
+   - content cannot contain blocks
+   - name is not matched in #+end_name
+   - everything beside block is parsed as greater block (i.e. VERSE)
+ *)
+greater-block = greater-block-begin-line line* <greater-block-end-line>
+greater-block-begin-line = <#"#\+(BEGIN|begin)_"> greater-block-name [s greater-block-parameters] [s] <eol>
+greater-block-name = #"\S+"
 greater-block-parameters = anything-but-newline
+greater-block-end-line = <#"#\+(END|end)_"> greater-block-name [s] <eol>
 
-<anything-but-whitespace> = #"[^\r\n\s$]+"
-<anything-but-newline> = #"[^\n$]+"
+(* Blocks
+   https://orgmode.org/worg/dev/org-syntax.html#Blocks
+   VERSE block content is parsed, every other block is not.
+   block-data is mandatory for SRC and EXPORT.
+   Blocks where content is NOT parsed:
+ *)
+block-noparse = block-begin-line block-content <block-end-line>
+block-begin-line = <#"#\+(BEGIN_|begin_)"> block-name-noparse [s block-data] [s] <eol>
+block-data = anything-but-newline
+block-content = #"(.|\n)*?\n(?=#\+(END_|end_))" | ε
+block-end-line =             #"#\+(END_|end_)" block-name-noparse [s] <eol>
 
-greater-block-end-line = <"#+END_"> greater-block-name
+(* TODO for later: *)
+block-export-data = #"\w+"
+block-src-data = block-src-lang (* [block-src-switches] [block-src-args] *)
+block-src-lang = #"\S+"
+
+(* Mostly unused: block types. Everything beside block-name-noparse is
+   parsed as greater-block. *)
+block-name-noparse = #"COMMENT|comment|EXAMPLE|example|EXPORT|export|SRC|src"
+block-name-verse = #"VERSE|verse"
+block-name-greater = #"CENTER|center|QUOTE|quote"
+block-name-special = #"\S+"
+
+<anything-but-whitespace> = #"\S+"
+<anything-but-newline> = #"[^\n]+"
 
 drawer-begin-line = <":"> drawer-name <":">
 drawer-name = #"[a-zA-Z0-9-_]+"
 drawer-end-line = <":END:">
 
-dynamic-block-begin-line = <'#+BEGIN: '> dynamic-block-name [s dynamic-block-parameters]
-dynamic-block-end-line = <'#+END:'>
-
+(* Dynamic Blocks
+   https://orgmode.org/manual/Dynamic-Blocks.html
+   https://orgmode.org/worg/dev/org-syntax.html#Dynamic_Blocks
+ *)
+dynamic-block = dynamic-block-begin-line line* <dynamic-block-end-line>
+dynamic-block-begin-line = <#"#\+(BEGIN|begin):"> s dynamic-block-name [s dynamic-block-parameters] [s] <eol>
 dynamic-block-name = anything-but-whitespace
 dynamic-block-parameters = anything-but-newline
+dynamic-block-end-line = <#"#\+(END|end):"> [s] <eol>
 
 (* Footnotes
    https://www.gnu.org/software/emacs/manual/html_node/org/Footnotes.html

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -74,10 +74,10 @@ block = block-noparse | greater-block
    - everything beside block is parsed as greater block (i.e. VERSE)
  *)
 greater-block = greater-block-begin-line line* <greater-block-end-line>
-greater-block-begin-line = <#"#\+(BEGIN|begin)_"> greater-block-name [s greater-block-parameters] [s] <eol>
+greater-block-begin-line = <#"#\+(BEGIN|begin)_"> greater-block-name [s greater-block-parameters] [s]
 greater-block-name = #"\S+"
 greater-block-parameters = anything-but-newline
-greater-block-end-line = <#"#\+(END|end)_"> greater-block-name [s] <eol>
+greater-block-end-line = <#"#\+(END|end)_"> greater-block-name [s]
 
 (* Blocks
    https://orgmode.org/worg/dev/org-syntax.html#Blocks
@@ -86,10 +86,10 @@ greater-block-end-line = <#"#\+(END|end)_"> greater-block-name [s] <eol>
    Blocks where content is NOT parsed:
  *)
 block-noparse = block-begin-line block-content <block-end-line>
-block-begin-line = <#"#\+(BEGIN_|begin_)"> block-name-noparse [s block-data] [s] <eol>
+block-begin-line = <#"#\+(BEGIN_|begin_)"> block-name-noparse [s block-data] [s]
 block-data = anything-but-newline
 block-content = #"(.|\n)*?\n(?=#\+(END_|end_))" | ε
-block-end-line =             #"#\+(END_|end_)" block-name-noparse [s] <eol>
+block-end-line =             #"#\+(END_|end_)" block-name-noparse [s]
 
 (* TODO for later: *)
 block-export-data = #"\w+"
@@ -112,12 +112,12 @@ block-name-special = #"\S+"
    https://orgmode.org/worg/dev/org-syntax.html#Property_Drawers
  *)
 drawer = drawer-begin-line line* <drawer-end-line>
-<drawer-begin-line> = <':'> drawer-name <':'> [s] <eol>
+<drawer-begin-line> = <':'> drawer-name <':'> [s]
 drawer-name = #"[-\w]+"
-drawer-end-line = <':END:'> [s] <eol>
+drawer-end-line = <':END:'> [s]
 
 property-drawer = <property-drawer-begin-line> node-property-line* <drawer-end-line>
-property-drawer-begin-line = <':PROPERTIES:'> [s] <eol>
+property-drawer-begin-line = <':PROPERTIES:'> [s]
 
 (* Dynamic Blocks
    https://orgmode.org/manual/Dynamic-Blocks.html
@@ -127,7 +127,7 @@ dynamic-block = dynamic-block-begin-line line* <dynamic-block-end-line>
 dynamic-block-begin-line = <#"#\+(BEGIN|begin):"> s dynamic-block-name [s dynamic-block-parameters] [s] <eol>
 dynamic-block-name = anything-but-whitespace
 dynamic-block-parameters = anything-but-newline
-dynamic-block-end-line = <#"#\+(END|end):"> [s] <eol>
+dynamic-block-end-line = <#"#\+(END|end):"> [s]
 
 (* Footnotes
    https://www.gnu.org/software/emacs/manual/html_node/org/Footnotes.html

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -106,9 +106,18 @@ block-name-special = #"\S+"
 <anything-but-whitespace> = #"\S+"
 <anything-but-newline> = #"[^\n]+"
 
-drawer-begin-line = <":"> drawer-name <":">
-drawer-name = #"[a-zA-Z0-9-_]+"
-drawer-end-line = <":END:">
+(* Drawers
+   https://orgmode.org/manual/Drawers.html
+   https://orgmode.org/worg/dev/org-syntax.html#Drawers
+   https://orgmode.org/worg/dev/org-syntax.html#Property_Drawers
+ *)
+drawer = drawer-begin-line line* <drawer-end-line>
+<drawer-begin-line> = <':'> drawer-name <':'> [s] <eol>
+drawer-name = #"[-\w]+"
+drawer-end-line = <':END:'> [s] <eol>
+
+property-drawer = <property-drawer-begin-line> node-property-line* <drawer-end-line>
+property-drawer-begin-line = <':PROPERTIES:'> [s] <eol>
 
 (* Dynamic Blocks
    https://orgmode.org/manual/Dynamic-Blocks.html
@@ -143,7 +152,7 @@ keyword-line = <'#+'> keyword-key <':'> [<' '> keyword-value]
 keyword-key = #"[^\s:]+"
 keyword-value = anything-but-newline
 
-node-property-line = <':'> node-property-name [node-property-plus] <':'> [<' '> node-property-value]
+node-property-line = <':'> node-property-name [node-property-plus] <':'> [<' '> node-property-value] <eol>
 node-property-name = #"[^\s:+]+"
 node-property-plus = <"+">
 node-property-value = text

--- a/src/org_parser/transform.cljc
+++ b/src/org_parser/transform.cljc
@@ -5,7 +5,7 @@
 (defmulti reducer
   "The reducer multi method takes a `result` and a `line` and dispatches
   on the first element in `line`, which is the type (a keyword) of the
-  parsed line, e.g. `:head-line`, `:content-line`, etc."
+  parsed line, e.g. `:headline`, `:content-line`, etc."
   (fn [_ line] (first line)))
 
 
@@ -23,7 +23,7 @@
        (drop 1)))
 
 
-(defmethod reducer :head-line [state [_ & properties]]
+(defmethod reducer :headline [state [_ & properties]]
   (let [level (->> properties
                    (property :stars)
                    first

--- a/test/org_parser/parser_mean_test.cljc
+++ b/test/org_parser/parser_mean_test.cljc
@@ -4,7 +4,7 @@
                :cljs [cljs.test :refer-macros [deftest is testing]])))
 
 (deftest headline
-  (let [parse #(parser/org % :start :head-line)]
+  (let [parse #(parser/org % :start :headline)]
     (testing "with crazy characters in title"
       (is (= [:headline [:stars "*****"] [:title "hello" "wörld⛄" ":"]]
              (parse "***** hello wörld⛄ :"))))))

--- a/test/org_parser/parser_mean_test.cljc
+++ b/test/org_parser/parser_mean_test.cljc
@@ -6,5 +6,5 @@
 (deftest headline
   (let [parse #(parser/org % :start :head-line)]
     (testing "with crazy characters in title"
-      (is (= [:head-line [:stars "*****"] [:title "hello" "wörld⛄" ":"]]
+      (is (= [:headline [:stars "*****"] [:title "hello" "wörld⛄" ":"]]
              (parse "***** hello wörld⛄ :"))))))

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -162,39 +162,6 @@ is another section"))))))
       (is (= [:todo-line [:todo-state "TODO"] [:done-state "DONE"]]
              (parse "#+TODO: TODO | DONE"))))))
 
-(deftest greater-blocks
-  (let [parse #(parser/org % :start :greater-block)]
-    (testing "no content"
-      (is (= [:greater-block
-              [:greater-block-begin-line [:greater-block-name "center"] [:greater-block-parameters "params! "]]]
-             (parse "#+BEGIN_center params! \n#+end_center\n"))))
-    (testing "one line of content"
-      (is (= [:greater-block [:greater-block-begin-line [:greater-block-name "center"]]
-              [:content-line "content"]]
-             (parse "#+BEGIN_center \ncontent\n#+end_center \n"))))
-    (testing "more lines of content"
-      (is (= [:greater-block [:greater-block-begin-line [:greater-block-name "center"]]
-              [:content-line "my"] [:content-line "content"]]
-             (parse "#+BEGIN_center\nmy\ncontent\n#+end_center\n"))))
-    ;; TODO this is a problem:
-    ;; (testing "fail if block name not matching"
-    ;;   (is (insta/failure? (parse "#+BEGIN_one\n#+end_other\n"))))
-    ))
-
-(deftest block-noparse
-  (let [parse #(parser/org % :start :block-noparse)]
-    (testing "no content"
-      (is (= [:block-noparse [:block-begin-line [:block-name-noparse "example"]] [:block-content]]
-             (parse "#+BEGIN_example\n#+end_example\n"))))
-    (testing "one line of content"
-      (is (= [:block-noparse [:block-begin-line [:block-name-noparse "example"]] [:block-content "content\n"]]
-             (parse "#+BEGIN_example \ncontent\n#+end_example\n"))))
-    (testing "content"
-      (is (= [:block-noparse [:block-begin-line [:block-name-noparse "SRC"] [:block-data "some useless data"]]
-              [:block-content "multi\nline\ncontent\n"]]
-             (parse "#+begin_SRC some useless data\nmulti\nline\ncontent\n#+end_SRC \n"))))))
-
-
 (deftest greater-block-begin
   (let [parse #(parser/org % :start :greater-block-begin-line)]
     (testing "greater-block-begin"
@@ -245,47 +212,15 @@ is another section"))))))
 ;; TODO: merge tests for drawer and drawers?
 (deftest drawer
   (testing "simple"
-    (is (= [:S [:drawer-begin-line [:drawer-name "SOMENAME"]] [:drawer-end-line]]
+    (is (= [:S [:drawer-name "SOMENAME"] [:drawer-end-line]]
            (parser/org ":SOMENAME:
 :END:"))))
   (testing "with a bit of content"
     (is (= [:S
-            [:drawer-begin-line [:drawer-name "PROPERTIES"]]
+            [:drawer-name "PROPERTIES"]
             [:content-line ":foo: bar"]
             [:drawer-end-line]]
            (parser/org ":PROPERTIES:\n:foo: bar\n:END:")))))
-
-(deftest drawers
-  (let [parse #(parser/org % :start :drawer)]
-    (testing "drawer"
-      (is (= [:drawer [:drawer-name "MYDRAWER"]
-              [:content-line "any"] [:content-line "text"]]
-             (parse ":MYDRAWER:\nany\ntext\n:END:"))))))
-
-(deftest property-drawers
-  (let [parse #(parser/org % :start :property-drawer)]
-    (testing "no properties"
-      (is (= [:property-drawer]
-             (parse ":PROPERTIES:\n:END:"))))
-    (testing "one property"
-      (is (= [:property-drawer [:node-property-line
-                                [:node-property-name "text"]
-                                [:node-property-plus]
-                                [:node-property-value "my value"]]]
-             (parse ":PROPERTIES:\n:text+: my value\n:END:"))))
-    (testing "more properties"
-      (is (= [:property-drawer
-	      [:node-property-line
-	       [:node-property-name "text"]
-	       [:node-property-plus]
-	       [:node-property-value "my value"]]
-	      [:node-property-line
-	       [:node-property-name "PRO"]
-	       [:node-property-value "abc"]]]
-             (parse ":PROPERTIES:\n:text+: my value\n:PRO: abc\n:END:"))))
-    (testing "can only contain properties"
-      (is (insta/failure? (parse ":PROPERTIES:\ntext\n:END:"))))
-    ))
 
 (deftest dynamic-block-begin
   (let [parse #(parser/org % :start :dynamic-block-begin-line)]

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -61,6 +61,24 @@
     ))
 
 
+(deftest line
+  (let [parse #(parser/org % :start :line)]
+    (testing "horizontal rule"
+      (is (= [[:horizontal-rule "-----"]]
+             (parse "-----"))))
+    (testing "horizontal rule space-indented"
+      (is (= [[:horizontal-rule " --------"]]
+             (parse " --------"))))
+    ))
+
+;; (deftest content
+;;   (let [parse #(parser/org % :start :content-line)]
+;;     (testing "boring"
+;;       (is (= [[:content-line "anything"]
+;;               [:content-line "goes"]]
+;;              (parse "anything\ngoes"))))))
+
+
 (deftest sections
   (let [parse parser/org]
     (testing "boring"

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -209,7 +209,6 @@ is another section"))))))
       (is (= [:drawer-end-line]
              (parse ":END:"))))))
 
-;; TODO: merge tests for drawer and drawers?
 (deftest drawer
   (testing "simple"
     (is (= [:S [:drawer-name "SOMENAME"] [:drawer-end-line]]

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -69,6 +69,29 @@
     (testing "horizontal rule space-indented"
       (is (= [[:horizontal-rule " --------"]]
              (parse " --------"))))
+
+    (testing "keyword line"
+      (is (= [[:keyword-line [:keyword-key "KEY"] [:keyword-value "VALUE"]]]
+             (parse "#+KEY: VALUE"))))
+
+    (testing "comment line"
+      (is (= [[:comment-line [:comment-line-head "#"] [:comment-line-rest ""]]]
+             (parse "#"))))
+    (testing "comment line"
+      (is (= [[:comment-line [:comment-line-head "#"] [:comment-line-rest " "]]]
+             (parse "# "))))
+    (testing "comment line"
+      (is (= [[:comment-line [:comment-line-head "#"] [:comment-line-rest " comment"]]]
+             (parse "# comment"))))
+    (testing "comment line"
+      (is (= [[:comment-line [:comment-line-head "\t#"] [:comment-line-rest " comment"]]]
+             (parse "\t# comment"))))
+    (testing "no valid comment line"
+      (is (= [[:content-line "#comment"]]
+             (parse "#comment"))))
+    (testing "no valid comment line"
+      (is (= [[:content-line "#\tcomment"]]
+             (parse "#\tcomment"))))
     ))
 
 ;; (deftest content

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -180,20 +180,20 @@ is another section"))))))
       (is (= [:dynamic-block [:dynamic-block-begin-line
                               [:dynamic-block-name "na.me"]
                               [:dynamic-block-parameters "pa rams "]]]
-             (parse "#+BEGIN: na.me pa rams \n#+end:\n"))))
+             (parse "#+BEGIN: na.me pa rams \n#+end:"))))
     (testing "one line of content"
       (is (= [:dynamic-block [:dynamic-block-begin-line [:dynamic-block-name "name"]]
               [:content-line "text"]]
-             (parse "#+BEGIN: name \ntext\n#+end: \n"))))
+             (parse "#+BEGIN: name \ntext\n#+end: "))))
     ;; TODO doesn't work yet :(
     ;; (testing "parse reluctantly"
-    ;;   (is (insta/failure? (parse "#+BEGIN: name \n#+end:\n#+end:\n"))))
+    ;;   (is (insta/failure? (parse "#+BEGIN: name \n#+end:\n#+end:"))))
     (testing "content"
       (is (= [:dynamic-block [:dynamic-block-begin-line [:dynamic-block-name "abc"]]
 	      [:content-line "multi"]
 	      [:content-line "line"]
 	      [:content-line "content"]]
-             (parse "#+begin: abc \nmulti\nline\ncontent\n#+end: \n"))))))
+             (parse "#+begin: abc \nmulti\nline\ncontent\n#+end: "))))))
 
 
 

--- a/test/org_parser/transform_test.cljc
+++ b/test/org_parser/transform_test.cljc
@@ -29,10 +29,10 @@
 
 (def parse-tree
   [:S
-   [:head-line [:stars "*"] [:title "hello" "world"]]
+   [:headline [:stars "*"] [:title "hello" "world"]]
    [:content-line "this is the first section"]
    [:empty-line]
-   [:head-line [:stars "**"] [:title "and" "this"]]
+   [:headline [:stars "**"] [:title "and" "this"]]
    [:empty-line]
    [:content-line "is another section"]])
 


### PR DESCRIPTION
In this branch, I work on the higher level syntax according to https://orgmode.org/worg/dev/org-syntax.html

Specifically, I want to check out, if we can move away from line-based parsing towards more semantical blocks, called "elements". The orgmode parser used for export is also called org-element.el.

The spec says, that most elements of the syntax are not context-free and the categories for these elements are 

> “Greater elements”, “elements”, and “objects”

Greater elements are e.g. `#+BEGIN_EXAMPLE` blocks. Some of these blocks contain raw text (EXAMPLE, SRC, COMMENT, ...), others can contain formatted text (CENTER, QUOTE, ...). Hence, it's better to parse context-aware and parse the multi-line raw content in EXAMPLE but formatted text in CENTER block.

Also, paragraphs, multi-line footnote definitions, lists, tables, property drawers are maybe better parsed as units instead of line-based.

- [x] And implement comments: https://orgmode.org/manual/Comment-Lines.html