### PR TITLE
test: Add transform/parser regression test

### DIFF
--- a/test/org_parser/transform_test.cljc
+++ b/test/org_parser/transform_test.cljc
@@ -1,5 +1,6 @@
 (ns org-parser.transform-test
   (:require [org-parser.transform :as sut]
+            [org-parser.parser :as parser]
             #?(:clj [clojure.test :refer :all]
                :cljs [cljs.test :refer :all :include-macros true])))
 
@@ -42,6 +43,16 @@
    [:headline {:level 2, :title "and this"}]
    [:content "\nis another section\n"]])
 
+(deftest regression
+  (testing "`transform` works on structures provided by parser"
+    (let [parse parser/org]
+      (is (= parse-tree
+             (parse "* hello world
+this is the first section
+
+** and this
+
+is another section"))))))
 
 (deftest transform
   (testing "a full parsetree"


### PR DESCRIPTION
Making sure that the `transform` tests are written against actual output from the parser.