### PR TITLE
Fix drawer-end-line not parsed

### DIFF
--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -7,7 +7,7 @@
 
 S = line*
 
-<line> = (empty-line / head-line / affiliated-keyword-line / keyword-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-begin-line / drawer-end-line / list-item-line / footnote-line / fixed-width-line / content-line) eol
+<line> = (empty-line / head-line / affiliated-keyword-line / keyword-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-end-line / drawer-begin-line / list-item-line / footnote-line / fixed-width-line / content-line) eol
 
 empty-line = "" | #"\s+"
 (* TODO same as title text below. *)

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -142,6 +142,12 @@ is another section"))))))
       (is (= [:drawer-end-line]
              (parse ":END:"))))))
 
+(deftest drawer
+  (testing "drawer"
+    (is (= [:S [:drawer-begin-line [:drawer-name "SOMENAME"]] [:drawer-end-line]]
+           (parser/org ":SOMENAME:
+:END:")))))
+
 
 (deftest dynamic-block-begin
   (let [parse #(parser/org % :start :dynamic-block-begin-line)]


### PR DESCRIPTION
Since `drawer-begin-line` had a higher priority than `drawer-end-line` all end lines have been parsed as begin lines.

This issue was already found in #6 and a solution which includes fixing the parsing of the `property-line` was already started. But the issue with the `end-line` can be fixed without a proper `property-line` parsing.