### PR TITLE
fix: Some tests never ran, because their name was overwritten

### DIFF
--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -184,8 +184,9 @@ node-property-value = text
 
 timestamp = timestamp-diary / timestamp-active / timestamp-inactive
 
-timestamp-diary = <'<%%('> ts-diary-sexp <')>'>
-<ts-diary-sexp> = #"(\)(?!>)|[^)>\n])*"
+(* "SEXP can contain any character excepted > and \n." *)
+timestamp-diary = <'<%%'> ts-diary-sexp <'>'>
+<ts-diary-sexp> = #"[^>\n]*"
 
 (* TODO How does that work out: :ts-inner appearing two times in :timestamp-active.
         And if it works in clojure, does it also work in JS hashes (parse result)? *)

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -465,7 +465,8 @@ is another section"))))))
       ;; http://xahlee.info/clojure/clojure_instaparse.html
       (is (insta/failure? (parse "<2020-04-17\nFri>"))))))
 
-(deftest timestamp
+
+(deftest timestamp-ts-time
   (let [parse #(parser/org % :start :ts-time)]
     (testing "parse time"
       (is (= [:ts-time "08:00"]
@@ -482,7 +483,6 @@ is another section"))))))
     (testing "parse time p.m."
       (is (= [:ts-time "08:00pm"]
              (parse "08:00pm"))))))
-
 
 
 (deftest literal-line

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -346,7 +346,7 @@ is another section"))))))
 (deftest timestamp
   (let [parse #(parser/org % :start :timestamp)]
     (testing "diary timestamp"
-      (is (= [:timestamp [:timestamp-diary ""]]
+      (is (= [:timestamp [:timestamp-diary "(( <(sexp)().))"]]
              (parse "<%%(( <(sexp)().))>"))))
     (testing "date timestamp without day"
       (is (= [:timestamp [:timestamp-active [:ts-inner [:ts-inner-wo-time [:ts-date "2020-01-18"]] [:ts-modifiers]]]]


### PR DESCRIPTION
Defining `(deftest timestamp ...)` twice in the same file will redefine `deftest`. So only the latter ran.

However, now a test is red. Maybe someone wants to take over fixing it.


----

#