### PR TITLE
Tests for semantic block parsing of drawers

### DIFF
--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -25,6 +25,9 @@ comment-line-rest = #".*"
 <s> = <#"[\t ]+">
 <word> = #"[^\r\n\s]+"
 
+<anything-but-whitespace> = #"\S+"
+<anything-but-newline> = #"[^\n]+"
+
 headline = stars [s keyword] [s priority] [s comment-token] s title [s tags]
 stars = #'\*+'
 keyword = #"[A-Z]+"
@@ -90,9 +93,6 @@ block-name-noparse = #"COMMENT|comment|EXAMPLE|example|EXPORT|export|SRC|src"
 block-name-verse = #"VERSE|verse"
 block-name-greater = #"CENTER|center|QUOTE|quote"
 block-name-special = #"\S+"
-
-<anything-but-whitespace> = #"\S+"
-<anything-but-newline> = #"[^\n]+"
 
 (* Drawers
    https://orgmode.org/manual/Drawers.html

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -144,8 +144,7 @@ keyword-value = anything-but-newline
 node-property-line = ! <':END:'> <':'> node-property-name [node-property-plus] <':'> ( <' '> node-property-value | [<' '>] ) <eol>
 node-property-name = #"[^\s:+]+"
 node-property-plus = <"+">
-node-property-value = #".*"
-(* TODO parse property value as text *)
+node-property-value = text
 
 
 (* timestamps
@@ -283,7 +282,7 @@ text-link-plain-path = #"[^\s()<>]+(\w|[^\s[:punct:]]/)"
    It can result in multiple subsequent text-normal which will be
    concated in a later transform step.
  *)
-text-normal = #".[^*/_=~+\[<{^\\]*"
+text-normal = #"[^\n\r][^*/_=~+\[<{^\\\n\r]*"
 
 (* Superscript and subscript
    https://orgmode.org/worg/dev/org-syntax.html#Subscript_and_Superscript

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -7,7 +7,7 @@
 
 S = line*
 
-<line> = (empty-line / headline / affiliated-keyword-line / keyword-line / comment-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-end-line / drawer-begin-line / list-item-line / footnote-line / fixed-width-line / horizontal-rule / content-line) eol
+<line> = (empty-line / headline / affiliated-keyword-line / keyword-line / comment-line / todo-line / block-begin-line / block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-end-line / drawer-begin-line / list-item-line / footnote-line / fixed-width-line / horizontal-rule / content-line) eol
 
 empty-line = "" | #"\s+"
 (* TODO same as title text below. *)
@@ -61,43 +61,31 @@ todo-line = <"#+TODO: "> states
 todo-state = #"[A-Z]+"
 done-state = #"[A-Z]+"
 
-(* TODO blocks - see greater-block for why this is faulty *)
-block = block-noparse | greater-block
-
-(* Greater Blocks - can contain Blocks
+(* Blocks and Greater Blocks
+   https://orgmode.org/worg/dev/org-syntax.html#Blocks
    https://orgmode.org/worg/dev/org-syntax.html#Greater_Blocks
 
+   Both are syntax like #+BEGIN_NAME xxx … #+END_NAME
+
+   Greater blocks can contain "any other element or greater element"
+   except elements of their own type (i.e. no blocks!) and some other.
+
    TODO currently blocks have many problems:
-   - content is parsed greedy
-   - content cannot contain blocks
+   - content is parsed greedy (doesn't stop at first #+end_name)
    - name is not matched in #+end_name
-   - everything beside block is parsed as greater block (i.e. VERSE)
  *)
-greater-block = greater-block-begin-line line* <greater-block-end-line>
-greater-block-begin-line = <#"#\+(BEGIN|begin)_"> greater-block-name [s greater-block-parameters] [s]
-greater-block-name = #"\S+"
-greater-block-parameters = anything-but-newline
-greater-block-end-line = <#"#\+(END|end)_"> greater-block-name [s]
+block = block-begin-line <eol> line* <block-end-line>
+block-begin-line = <#"#\+(BEGIN|begin)_"> block-name [s block-parameters] [s]
+block-name = #"\S+"
+block-parameters = anything-but-newline
+block-end-line = <#"#\+(END|end)_"> block-name [s]
 
-(* Blocks
-   https://orgmode.org/worg/dev/org-syntax.html#Blocks
-   VERSE block content is parsed, every other block is not.
-   block-data is mandatory for SRC and EXPORT.
-   Blocks where content is NOT parsed:
- *)
-block-noparse = block-begin-line block-content <block-end-line>
-block-begin-line = <#"#\+(BEGIN_|begin_)"> block-name-noparse [s block-data] [s]
-block-data = anything-but-newline
-block-content = #"(.|\n)*?\n(?=#\+(END_|end_))" | ε
-block-end-line =             #"#\+(END_|end_)" block-name-noparse [s]
-
-(* TODO for later: *)
+(* Data/parameters of blocks (coming after #+BEGIN_NAME) *)
 block-export-data = #"\w+"
 block-src-data = block-src-lang (* [block-src-switches] [block-src-args] *)
 block-src-lang = #"\S+"
 
-(* Mostly unused: block types. Everything beside block-name-noparse is
-   parsed as greater-block. *)
+(* Block types. Content of blocks with block-name-noparse is NOT parsed. *)
 block-name-noparse = #"COMMENT|comment|EXAMPLE|example|EXPORT|export|SRC|src"
 block-name-verse = #"VERSE|verse"
 block-name-greater = #"CENTER|center|QUOTE|quote"
@@ -111,20 +99,20 @@ block-name-special = #"\S+"
    https://orgmode.org/worg/dev/org-syntax.html#Drawers
    https://orgmode.org/worg/dev/org-syntax.html#Property_Drawers
  *)
-drawer = drawer-begin-line line* <drawer-end-line>
-<drawer-begin-line> = <':'> drawer-name <':'> [s]
+drawer = drawer-begin-line <eol> line* <drawer-end-line>
+drawer-begin-line = <':'> drawer-name <':'> [s]
 drawer-name = #"[-\w]+"
 drawer-end-line = <':END:'> [s]
 
-property-drawer = <property-drawer-begin-line> node-property-line* <drawer-end-line>
+property-drawer = <property-drawer-begin-line> <eol> node-property-line* <drawer-end-line>
 property-drawer-begin-line = <':PROPERTIES:'> [s]
 
 (* Dynamic Blocks
    https://orgmode.org/manual/Dynamic-Blocks.html
    https://orgmode.org/worg/dev/org-syntax.html#Dynamic_Blocks
  *)
-dynamic-block = dynamic-block-begin-line line* <dynamic-block-end-line>
-dynamic-block-begin-line = <#"#\+(BEGIN|begin):"> s dynamic-block-name [s dynamic-block-parameters] [s] <eol>
+dynamic-block = dynamic-block-begin-line <eol> line* <dynamic-block-end-line>
+dynamic-block-begin-line = <#"#\+(BEGIN|begin):"> s dynamic-block-name [s dynamic-block-parameters] [s]
 dynamic-block-name = anything-but-whitespace
 dynamic-block-parameters = anything-but-newline
 dynamic-block-end-line = <#"#\+(END|end):"> [s]
@@ -153,11 +141,11 @@ keyword-key = #"[^\s:]+"
 keyword-value = anything-but-newline
 
 (* TODO allow empty properties with or without trailing space *)
-(* TODO looks like node-property-line also parses :END: *)
 node-property-line = ! <':END:'> <':'> node-property-name [node-property-plus] <':'> ( <' '> node-property-value | [<' '>] ) <eol>
 node-property-name = #"[^\s:+]+"
 node-property-plus = <"+">
-node-property-value = text
+node-property-value = #".*"
+(* TODO parse property value as text *)
 
 
 (* timestamps

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -77,7 +77,7 @@ done-state = #"[A-Z]+"
    - content is parsed greedy (doesn't stop at first #+end_name)
    - name is not matched in #+end_name
  *)
-block = block-begin-line <eol> line* <block-end-line>
+block = block-begin-line <eol> line* block-end-line
 block-begin-line = <#"#\+(BEGIN|begin)_"> block-name [s block-parameters] [s]
 block-name = #"\S+"
 block-parameters = anything-but-newline

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -166,19 +166,25 @@ is another section"))))))
   (let [parse #(parser/org % :start :block)]
     (testing "no content"
       (is (= [:block
-              [:block-begin-line [:block-name "center"] [:block-parameters "params! "]]]
+              [:block-begin-line [:block-name "center"] [:block-parameters "params! "]]
+              [:block-end-line [:block-name "center"]]]
              (parse "#+BEGIN_center params! \n#+end_center"))))
     (testing "one line of content"
       (is (= [:block [:block-begin-line [:block-name "center"]]
-              [:content-line "content"]]
+              [:content-line "content"]
+              [:block-end-line [:block-name "center"]]]
              (parse "#+BEGIN_center \ncontent\n#+end_center "))))
     (testing "more lines of content"
       (is (= [:block [:block-begin-line [:block-name "center"]]
-              [:content-line "my"] [:content-line "content"]]
+              [:content-line "my"] [:content-line "content"]
+              [:block-end-line [:block-name "center"]]]
              (parse "#+BEGIN_center\nmy\ncontent\n#+end_center"))))
-    ;; TODO this is a problem:
-    ;; (testing "fail if block name not matching"
-    ;;   (is (insta/failure? (parse "#+BEGIN_one\n#+end_other\n"))))
+    (testing "parse even if block name at begin and end not matching"
+      ;; This must be handled by in a later step.
+      (is (= [:block
+              [:block-begin-line [:block-name "one"]]
+              [:block-end-line [:block-name "other"]]]
+             (parse "#+BEGIN_one\n#+end_other"))))
     ))
 
 (deftest block-begin

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -162,49 +162,35 @@ is another section"))))))
       (is (= [:todo-line [:todo-state "TODO"] [:done-state "DONE"]]
              (parse "#+TODO: TODO | DONE"))))))
 
-(deftest greater-blocks
-  (let [parse #(parser/org % :start :greater-block)]
+(deftest blocks
+  (let [parse #(parser/org % :start :block)]
     (testing "no content"
-      (is (= [:greater-block
-              [:greater-block-begin-line [:greater-block-name "center"] [:greater-block-parameters "params! "]]]
-             (parse "#+BEGIN_center params! \n#+end_center\n"))))
+      (is (= [:block
+              [:block-begin-line [:block-name "center"] [:block-parameters "params! "]]]
+             (parse "#+BEGIN_center params! \n#+end_center"))))
     (testing "one line of content"
-      (is (= [:greater-block [:greater-block-begin-line [:greater-block-name "center"]]
+      (is (= [:block [:block-begin-line [:block-name "center"]]
               [:content-line "content"]]
-             (parse "#+BEGIN_center \ncontent\n#+end_center \n"))))
+             (parse "#+BEGIN_center \ncontent\n#+end_center "))))
     (testing "more lines of content"
-      (is (= [:greater-block [:greater-block-begin-line [:greater-block-name "center"]]
+      (is (= [:block [:block-begin-line [:block-name "center"]]
               [:content-line "my"] [:content-line "content"]]
-             (parse "#+BEGIN_center\nmy\ncontent\n#+end_center\n"))))
+             (parse "#+BEGIN_center\nmy\ncontent\n#+end_center"))))
     ;; TODO this is a problem:
     ;; (testing "fail if block name not matching"
     ;;   (is (insta/failure? (parse "#+BEGIN_one\n#+end_other\n"))))
     ))
 
-(deftest block-noparse
-  (let [parse #(parser/org % :start :block-noparse)]
-    (testing "no content"
-      (is (= [:block-noparse [:block-begin-line [:block-name-noparse "example"]] [:block-content]]
-             (parse "#+BEGIN_example\n#+end_example\n"))))
-    (testing "one line of content"
-      (is (= [:block-noparse [:block-begin-line [:block-name-noparse "example"]] [:block-content "content\n"]]
-             (parse "#+BEGIN_example \ncontent\n#+end_example\n"))))
-    (testing "content"
-      (is (= [:block-noparse [:block-begin-line [:block-name-noparse "SRC"] [:block-data "some useless data"]]
-              [:block-content "multi\nline\ncontent\n"]]
-             (parse "#+begin_SRC some useless data\nmulti\nline\ncontent\n#+end_SRC \n"))))))
-
-
-(deftest greater-block-begin
-  (let [parse #(parser/org % :start :greater-block-begin-line)]
-    (testing "greater-block-begin"
-      (is (= [:greater-block-begin-line [:greater-block-name "CENTER"] [:greater-block-parameters "some params"]]
+(deftest block-begin
+  (let [parse #(parser/org % :start :block-begin-line)]
+    (testing "block-begin"
+      (is (= [:block-begin-line [:block-name "CENTER"] [:block-parameters "some params"]]
              (parse "#+BEGIN_CENTER some params"))))))
 
-(deftest greater-block-end
-  (let [parse #(parser/org % :start :greater-block-end-line)]
-    (testing "greater-block-end"
-      (is (= [:greater-block-end-line [:greater-block-name "CENTER"]]
+(deftest block-end
+  (let [parse #(parser/org % :start :block-end-line)]
+    (testing "block-end"
+      (is (= [:block-end-line [:block-name "CENTER"]]
              (parse "#+END_CENTER"))))))
 
 (deftest dynamic-block
@@ -233,7 +219,7 @@ is another section"))))))
 (deftest drawer-begin
   (let [parse #(parser/org % :start :drawer-begin-line)]
     (testing "drawer-begin"
-      (is (= [[:drawer-name "SOMENAME"]]
+      (is (= [:drawer-begin-line [:drawer-name "SOMENAME"]]
              (parse ":SOMENAME:"))))))
 
 (deftest drawer-end
@@ -243,25 +229,25 @@ is another section"))))))
              (parse ":END:"))))))
 
 (deftest drawer
-  (testing "simple"
+  (testing "simple drawer"
     (is (= [:S [:drawer-begin-line [:drawer-name "SOMENAME"]] [:drawer-end-line]]
            (parser/org ":SOMENAME:
 :END:"))))
-  (testing "with a bit of content"
+  (testing "drawer with a bit of content"
     (is (= [:S
             [:drawer-begin-line [:drawer-name "PROPERTIES"]]
             [:content-line ":foo: bar"]
             [:drawer-end-line]]
            (parser/org ":PROPERTIES:\n:foo: bar\n:END:")))))
 
-(deftest drawers
+(deftest drawer-semantic-block
   (let [parse #(parser/org % :start :drawer)]
     (testing "drawer"
-      (is (= [:drawer [:drawer-name "MYDRAWER"]
+      (is (= [:drawer [:drawer-begin-line [:drawer-name "MYDRAWER"]]
               [:content-line "any"] [:content-line "text"]]
              (parse ":MYDRAWER:\nany\ntext\n:END:"))))))
 
-(deftest property-drawers
+(deftest property-drawer-semantic-block
   (let [parse #(parser/org % :start :property-drawer)]
     (testing "no properties"
       (is (= [:property-drawer]
@@ -398,13 +384,15 @@ is another section"))))))
     (testing "node-property"
       (is (= [:node-property-line
               [:node-property-name "HELLO"]
-              [:node-property-value [:text [:text-normal "hello world"]]]]
+              ;;[:node-property-value [:text [:text-normal "hello world"]]]]
+              [:node-property-value "hello world"]]
              (parse ":HELLO: hello world"))))
     (testing "node-property"
       (is (= [:node-property-line
               [:node-property-name "HELLO"]
               [:node-property-plus]
-              [:node-property-value [:text [:text-normal "hello world"]]]]
+              ;;[:node-property-value [:text [:text-normal "hello world"]]]]
+              [:node-property-value "hello world"]]
              (parse ":HELLO+: hello world"))))
     ))
 

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -256,17 +256,17 @@ is another section"))))))
       (is (= [:property-drawer [:node-property-line
                                 [:node-property-name "text"]
                                 [:node-property-plus]
-                                [:node-property-value "my value"]]]
+                                [:node-property-value [:text [:text-normal "my value"]]]]]
              (parse ":PROPERTIES:\n:text+: my value\n:END:"))))
     (testing "more properties"
       (is (= [:property-drawer
 	      [:node-property-line
 	       [:node-property-name "text"]
 	       [:node-property-plus]
-	       [:node-property-value "my value"]]
+	       [:node-property-value [:text [:text-normal "my value"]]]]
 	      [:node-property-line
 	       [:node-property-name "PRO"]
-	       [:node-property-value "abc"]]]
+	       [:node-property-value [:text [:text-normal "abc"]]]]]
              (parse ":PROPERTIES:\n:text+: my value\n:PRO: abc\n:END:"))))
     (testing "can only contain properties"
       (is (insta/failure? (parse ":PROPERTIES:\ntext\n:END:"))))
@@ -384,15 +384,13 @@ is another section"))))))
     (testing "node-property"
       (is (= [:node-property-line
               [:node-property-name "HELLO"]
-              ;;[:node-property-value [:text [:text-normal "hello world"]]]]
-              [:node-property-value "hello world"]]
+              [:node-property-value [:text [:text-normal "hello world"]]]]
              (parse ":HELLO: hello world"))))
     (testing "node-property"
       (is (= [:node-property-line
               [:node-property-name "HELLO"]
               [:node-property-plus]
-              ;;[:node-property-value [:text [:text-normal "hello world"]]]]
-              [:node-property-value "hello world"]]
+              [:node-property-value [:text [:text-normal "hello world"]]]]
              (parse ":HELLO+: hello world"))))
     ))
 
@@ -734,9 +732,6 @@ is another section"))))))
     (testing "parse styled text alone"
       (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]]
              (parse "*bold text*"))))
-    (testing "if given multi-line text, parse bold text" ;; normally, parsing text is line-based
-      (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "a\nb"]]]]]
-             (parse "*a\nb*"))))
     (testing "parse styled text followed by normal text"
       (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]
               [:text-normal " normal text"]]


### PR DESCRIPTION
Reintroduce tests for parsing semantic blocks (e.g. drawers).

This PR *does not* enable parsing semantic block for org files. It only prepares for it.

Parsing semantic blocks can later be enabled by changing EBNF:

```patch
- <line> = (headline / drawer-begin-line / drawer-end-line / … / content-line) eol
+ <line> = (headline / drawer / … / content-line) eol
```
