### PR TITLE
[WIP] Parse content-line as text instead of just .*

### DIFF
--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -251,11 +251,12 @@ text = ( link-format / footnote-link / text-link / text-target / text-radio-targ
  *)
 text-styled = text-sty-bold / text-sty-italic / text-sty-underlined / text-sty-strikethrough / text-sty-verbatim / text-sty-code
 
+(* Do not try to parse styled text recursively. Only parse simplest form of styled text. *)
 (* TODO simplest possible solution; ignores ways of escaping and does not allow the delim to appear inside *)
-text-sty-bold          = <'*'> text <'*'>
-text-sty-italic        = <'/'> text <'/'>
-text-sty-underlined    = <'_'> text <'_'>
-text-sty-strikethrough = <'+'> text <'+'>
+text-sty-bold          = <'*'> text-inside-sty-normal <'*'>
+text-sty-italic        = <'/'> text-inside-sty-normal <'/'>
+text-sty-underlined    = <'_'> text-inside-sty-normal <'_'>
+text-sty-strikethrough = <'+'> text-inside-sty-normal <'+'>
 (* https://orgmode.org/worg/dev/org-syntax.html#Emphasis_Markers is wrong at this point:
    The BORDER character in =BxB= must not be whitespace but can be [,'"]. *)
 text-sty-verbatim      = <'='> #"([^\s]|[^\s].*?[^\s])(?==($|[- \t.,:!?;'\")}\[]))" <'='>

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -296,7 +296,7 @@ text-link-plain-path = #"[^\s()<>]+(\w|[^\s[:punct:]]/)"
 
    Stop parsing at EOL.
  *)
-text-normal = #"[^\n\r][^*/_=~+\[<{^\\\n\r]*"
+text-normal = #".[^*/_=~+\[<{^\\\n\r]*"
 
 (* Superscript and subscript
    https://orgmode.org/worg/dev/org-syntax.html#Subscript_and_Superscript

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -10,9 +10,7 @@ S = line*
 <line> = (empty-line / headline / affiliated-keyword-line / keyword-line / comment-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-end-line / drawer-begin-line / list-item-line / footnote-line / fixed-width-line / horizontal-rule / content-line) eol
 
 empty-line = "" | #"\s+"
-(* TODO same as title text below. *)
-content-line = #".*"
-(* content-line = text *)
+content-line = text
 
 (* "Comments consist of one or more consecutive comment lines."
    https://orgmode.org/worg/dev/org-syntax.html#Comments *)

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -267,7 +267,7 @@ before-sty = #"[- ('\"{]|"
 (* first and last character must not be whitespace. that's why it's not just text *)
 text-inside-sty = ( link-format / footnote-link / text-link / text-styled / text-inside-sty-normal )*
 (* TODO space works? includes newline? *)
-text-inside-sty-normal = #"([^ ]|[^ ].*?[^ ])(?=\*([- .,:!?;'\")}\[]|$))"
+text-inside-sty-normal = #"([^ ]|[^ ].*?[^ ])(?=[*/_+]([- .,:!?;'\")}\[]|$))"
 
 (* There are 4 types of links: radio link (not subject to this
    parser), angle link, plain link, and regular link
@@ -292,8 +292,10 @@ text-link-plain-path = #"[^\s()<>]+(\w|[^\s[:punct:]]/)"
    This works so far because when parsing, text-normal is tried last.
    It can result in multiple subsequent text-normal which will be
    concated in a later transform step.
+
+   Stop parsing at EOL.
  *)
-text-normal = #".[^*/_=~+\[<{^\\]*"
+text-normal = #"[^\n\r][^*/_=~+\[<{^\\\n\r]*"
 
 (* Superscript and subscript
    https://orgmode.org/worg/dev/org-syntax.html#Subscript_and_Superscript

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -9,6 +9,7 @@ S = line*
 
 <line> = (empty-line / headline / affiliated-keyword-line / keyword-line / comment-line / todo-line / greater-block-begin-line / greater-block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-end-line / drawer-begin-line / list-item-line / footnote-line / fixed-width-line / horizontal-rule / content-line) eol
 
+(* TODO delete empty-line token? because it discards whitespace which may not be desired. *)
 empty-line = "" | #"\s+"
 content-line = text
 

--- a/src/org_parser/parser.clj
+++ b/src/org_parser/parser.clj
@@ -1,4 +1,10 @@
 (ns org-parser.parser
   (:require [instaparse.core :as insta]))
 
-(def org (insta/parser (clojure.java.io/resource "org.ebnf")))
+
+(defn org [& args]
+  (-> "org.ebnf"
+      clojure.java.io/resource
+      insta/parser
+      (apply args)
+      (vary-meta merge {:raw (first args)})))

--- a/src/org_parser/parser.cljs
+++ b/src/org_parser/parser.cljs
@@ -5,4 +5,8 @@
 
 (def fs (js/require "fs"))
 
-(defparser org (.readFileSync fs "resources/org.ebnf" "utf8"))
+(defparser org* (.readFileSync fs "resources/org.ebnf" "utf8"))
+
+(defn org [& args]
+  (-> (apply org* args)
+      (vary-meta merge {:raw (first args)})))

--- a/src/org_parser/transform.cljc
+++ b/src/org_parser/transform.cljc
@@ -1,21 +1,37 @@
 (ns org-parser.transform
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [instaparse.core :as insta]))
+
+
+(def conjv (comp vec conj))
 
 
 (defmulti reducer
-  "The reducer multi method takes a `result` and a `line` and dispatches
-  on the first element in `line`, which is the type (a keyword) of the
+  "The reducer multi method takes a RESULT and an AST and dispatches
+  on the first element in AST, which is the type (a keyword) of the
   parsed line, e.g. `:headline`, `:content-line`, etc."
-  (fn [_ line] (first line)))
+  (fn [_ line _] (first line)))
 
 
-(defmethod reducer :default [state line]
-  (conj state line))
+;; add the given ast to the section of the last headline or to the
+;; preamble if there are no headlines yet
+(defmethod reducer :default [state ast raw]
+  (let [loc (if-let [headlines (state :headlines)]
+              [:headlines (dec (count headlines)) :section]
+              [:preamble :section])]
+    (-> state
+        ;; append line to :ast
+        (update-in (conj loc :ast) conjv ast)
+        ;; append raw string to :raw
+        (update-in (conj loc :raw) conjv raw))))
+
+
+#_(transform (org-parser.parser/org "* hello\n** world\n\nasdf"))
 
 
 (defn- property
-  "Takes a `prop` (a keyword) and a seq `props`. Finds the occurence of
-  `prop` in `props` and returns a seq of its values."
+  "Takes a PROP (a keyword) and a seq PROPS. Finds the occurence of
+  PROP in PROPS and returns a seq of its values."
   [prop props]
   (->> props
        (filter #(= prop (first %)))
@@ -23,7 +39,7 @@
        (drop 1)))
 
 
-(defmethod reducer :headline [state [_ & properties]]
+(defmethod reducer :headline [state [_ & properties] raw]
   (let [level (->> properties
                    (property :stars)
                    first
@@ -31,31 +47,22 @@
         title (->> properties
                    (property :title)
                    (str/join " "))]
-    (conj state [:headline {:level level
-                            :title title}])))
+    ;; a headline introduces a new headline
+    (update state :headlines conjv {:headline {:level level
+                                               :title title}})))
 
 
-(defn- append
-  "Takes `state` which is the current result while transforming and a
-  content-line's `text`. Adds the `text` to the text of the last entry
-  of `state`."
-  [state text]
-  (let [keep (pop state)
-        [key content] (last state)]
-    (conj keep [key (str content text "\n")])))
+;; content-line needs to simply drop the keyword
+(defmethod reducer :content-line [state [_ ast] raw]
+  (reducer state ast raw))
 
 
-(defmethod reducer :content-line [state [_ text]]
-  (if (-> state last first (= :content))
-    (append state text)
-    (conj state [:content (str text "\n")])))
-
-
-(defmethod reducer :empty-line [state [_ _]]
-  (reducer state [:content-line ""]))
+(defn- wrap-raw [reducer raw]
+  (fn [agg ast]
+    (reducer agg ast (apply subs raw (insta/span ast)))))
 
 
 (defn transform [x]
   (->> x
        (drop 1) ;; drops the initial `:S`
-       (reduce reducer [])))
+       (reduce (wrap-raw reducer (-> x meta :raw)) {})))

--- a/test/org_parser/core_test.cljc
+++ b/test/org_parser/core_test.cljc
@@ -4,15 +4,7 @@
             #?(:cljs [cljs-node-io.core :refer [slurp]])
             [org-parser.core :as core]))
 
-(def ^:private sample
-  (slurp "test/org_parser/fixtures/bold_text.org"))
-
 (deftest full-round-trip
-  (testing "read then write equals identity"
-    (is (= sample (-> sample core/read-str core/write-str)))))
-
-(deftest read-str
-  (testing "reads the string"
-    (is (= [[:headline {:level 1, :title "Main header (required for parser atm)"}]
-            [:content "*This is bold*: Hello spec!\n\n*Bold* text can also be just one word.\n\n*This is also bold*: And here goes for some more text which even\n includes more *bold* statements.\n"]]
-           (-> sample core/read-str)))))
+  (testing "minimal"
+    (let [minimal (slurp "test/org_parser/fixtures/minimal.org")]
+      (is (= minimal (-> minimal core/read-str core/write-str))))))

--- a/test/org_parser/fixtures/minimal.org
+++ b/test/org_parser/fixtures/minimal.org
@@ -1,0 +1,1 @@
+* Hello World

--- a/test/org_parser/integration/section_test.cljc
+++ b/test/org_parser/integration/section_test.cljc
@@ -45,7 +45,7 @@
 
 
 (deftest section
-  (doseq [{:keys [input ast result]} samples]
+  (doseq [{:keys [input ast result output]} samples]
     (let [ast* (parser/org input)]
       (if ast (is (= ast ast*)))
       (if result (is (= result (transform/transform ast*)))))))

--- a/test/org_parser/integration/section_test.cljc
+++ b/test/org_parser/integration/section_test.cljc
@@ -1,0 +1,54 @@
+(ns org-parser.integration.section-test
+  (:require [clojure.string :as str]
+            [org-parser.parser :as parser]
+            [org-parser.transform :as transform]
+            #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+
+(defn- t [& l] (str/join "\n" l))
+
+
+(def samples
+  [{:input
+    (t "* hello world"
+       "this is the first section"
+       "this line has *bold text*")
+
+    :ast
+    [:S
+     [:headline [:stars "*"] [:title "hello" "world"]]
+     [:content-line [:text [:text-normal "this is the first section"]]]
+     [:content-line
+      [:text
+       [:text-normal "this line has "]
+       [:text-styled
+        [:text-sty-bold [:text-inside-sty-normal "bold text"]]]]]]
+
+    :result
+    {:headlines
+     [{:headline {:level 1
+                  :title "hello world"}
+       :section
+       {:raw ["this is the first section" "this line has *bold text*"]
+        :ast [[:text [:text-normal "this is the first section"]]
+              [:text
+               [:text-normal "this line has "]
+               [:text-styled
+                [:text-sty-bold [:text-inside-sty-normal "bold text"]]]]]}}]}}
+
+   ;; next sample here:
+   ;; {:input ...
+   ;;  :ast ...
+   ;;  :result ...}
+   ])
+
+
+(deftest section
+  (doseq [{:keys [input ast result]} samples]
+    (let [ast* (parser/org input)]
+      (if ast (is (= ast ast*)))
+      (if result (is (= result (transform/transform ast*)))))))
+
+
+#_(-> samples first :input parser/org transform/transform)

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -676,6 +676,8 @@ is another section"))))))
     (testing "stop parsing text at EOL"
       (is (= [:text [:text-normal "abc "]]
              (parse "abc "))))
+    (testing "does not parse a string starting with newline"
+      (is (insta/failure? (parse "\nfoo"))))
     (testing "parse text that contains style delimiter"
       (is (= [:text [:text-normal "a"] [:text-normal "/b"]]
              (parse "a/b"))))

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -108,9 +108,9 @@
     (testing "boring org file"
       (is (= [:S
               [:headline [:stars "*"] [:title "hello" "world"]]
-              [:content-line "this is the first section"]
+              [:content-line [:text [:text-normal "this is the first section"]]]
               [:headline [:stars "**"] [:title "and" "this"]]
-              [:content-line "is another section"]]
+              [:content-line [:text [:text-normal "is another section"]]]]
              (parse "* hello world
 this is the first section
 ** and this
@@ -118,11 +118,11 @@ is another section"))))
     (testing "boring org file with empty lines"
       (is (=[:S
              [:headline [:stars "*"] [:title "hello" "world"]]
-             [:content-line "this is the first section"]
+             [:content-line [:text [:text-normal "this is the first section"]]]
              [:empty-line]
              [:headline [:stars "**"] [:title "and" "this"]]
              [:empty-line]
-             [:content-line "is another section"]]
+             [:content-line [:text [:text-normal "is another section"]]]]
             (parse "* hello world
 this is the first section
 
@@ -184,16 +184,16 @@ is another section"))))))
              (parse "#+BEGIN: na.me pa rams \n#+end:"))))
     (testing "one line of content"
       (is (= [:dynamic-block [:dynamic-block-begin-line [:dynamic-block-name "name"]]
-              [:content-line "text"]]
+              [:content-line [:text [:text-normal "text"]]]]
              (parse "#+BEGIN: name \ntext\n#+end: "))))
     ;; TODO doesn't work yet :(
     ;; (testing "parse reluctantly"
     ;;   (is (insta/failure? (parse "#+BEGIN: name \n#+end:\n#+end:"))))
     (testing "content"
       (is (= [:dynamic-block [:dynamic-block-begin-line [:dynamic-block-name "abc"]]
-	      [:content-line "multi"]
-	      [:content-line "line"]
-	      [:content-line "content"]]
+	      [:content-line [:text [:text-normal "multi"]]]
+	      [:content-line [:text [:text-normal "line"]]]
+	      [:content-line [:text [:text-normal "content"]]]]
              (parse "#+begin: abc \nmulti\nline\ncontent\n#+end: "))))))
 
 
@@ -218,7 +218,7 @@ is another section"))))))
   (testing "with a bit of content"
     (is (= [:S
             [:drawer-name "PROPERTIES"]
-            [:content-line ":foo: bar"]
+            [:content-line [:text [:text-normal ":foo: bar"]]]
             [:drawer-end-line]]
            (parser/org ":PROPERTIES:\n:foo: bar\n:END:")))))
 

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -616,13 +616,13 @@ is another section"))))))
 (deftest text-styled
   (let [parse #(parser/org % :start :text-styled)]
     (testing "parse bold text"
-      (is (= [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]
+      (is (= [:text-styled [:text-sty-bold [:text-inside-sty-normal "bold text"]]]
              (parse "*bold text*"))))
     (testing "parse italic text"
-      (is (= [:text-styled [:text-sty-italic [:text [:text-normal "italic text"]]]]
+      (is (= [:text-styled [:text-sty-italic [:text-inside-sty-normal "italic text"]]]
              (parse "/italic text/"))))
     (testing "parse underlined text"
-      (is (= [:text-styled [:text-sty-underlined [:text [:text-normal "underlined text"]]]]
+      (is (= [:text-styled [:text-sty-underlined [:text-inside-sty-normal "underlined text"]]]
              (parse "_underlined text_"))))
     (testing "parse verbatim text"
       (is (= [:text-styled [:text-sty-verbatim "verbatim /abc/ text"]]
@@ -631,7 +631,7 @@ is another section"))))))
       (is (= [:text-styled [:text-sty-code "code *abc* text"]]
              (parse "~code *abc* text~"))))
     (testing "parse strike-through text"
-      (is (= [:text-styled [:text-sty-strikethrough [:text [:text-normal "strike-through text"]]]]
+      (is (= [:text-styled [:text-sty-strikethrough [:text-inside-sty-normal "strike-through text"]]]
              (parse "+strike-through text+"))))
     ;; parse reluctant
     ;; (testing "parse text-styled alone is not reluctant"
@@ -683,27 +683,24 @@ is another section"))))))
       (is (= [:text [:text-normal "a "] [:text-normal "/b"]]
              (parse "a /b"))))
     (testing "parse styled text alone"
-      (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]]
+      (is (= [:text [:text-styled [:text-sty-bold [:text-inside-sty-normal "bold text"]]]]
              (parse "*bold text*"))))
-    (testing "if given multi-line text, parse bold text" ;; normally, parsing text is line-based
-      (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "a\nb"]]]]]
-             (parse "*a\nb*"))))
     (testing "parse styled text followed by normal text"
-      (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]
+      (is (= [:text [:text-styled [:text-sty-bold [:text-inside-sty-normal "bold text"]]]
               [:text-normal " normal text"]]
              (parse "*bold text* normal text"))))
     (testing "parse normal text followed by styled text"
       (is (= [:text [:text-normal "normal text "]
-              [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]]
+              [:text-styled [:text-sty-bold [:text-inside-sty-normal "bold text"]]]]
              (parse "normal text *bold text*"))))
     (testing "parse styled text surrounded by normal text"
       (is (= [:text
               [:text-normal "normal text "]
-              [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]
+              [:text-styled [:text-sty-bold [:text-inside-sty-normal "bold text"]]]
               [:text-normal " more text"]]
              (parse "normal text *bold text* more text"))))
     (testing "parse styled text reluctant"
-      (is (= [:text [:text-styled [:text-sty-bold [:text [:text-normal "bold text"]]]]
+      (is (= [:text [:text-styled [:text-sty-bold [:text-inside-sty-normal "bold text"]]]
               [:text-normal " text"]
               [:text-normal "*"]]
              (parse "*bold text* text*"))))

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -86,13 +86,14 @@
     (testing "comment line"
       (is (= [[:comment-line [:comment-line-head "\t#"] [:comment-line-rest " comment"]]]
              (parse "\t# comment"))))
-    (testing "no valid comment line"
-      (is (= [[:content-line "#comment"]]
-             (parse "#comment"))))
-    (testing "no valid comment line"
-      (is (= [[:content-line "#\tcomment"]]
-             (parse "#\tcomment"))))
     ))
+
+(deftest comment-line
+  (let [parse #(parser/org % :start :comment-line)]
+    (testing "no valid comment line"
+      (is (insta/failure? (parse "#comment"))))
+    (testing "no valid comment line"
+      (is (insta/failure? (parse "#\tcomment"))))))
 
 ;; (deftest content
 ;;   (let [parse #(parser/org % :start :content-line)]
@@ -104,7 +105,7 @@
 
 (deftest sections
   (let [parse parser/org]
-    (testing "boring"
+    (testing "boring org file"
       (is (= [:S
               [:headline [:stars "*"] [:title "hello" "world"]]
               [:content-line "this is the first section"]
@@ -114,7 +115,7 @@
 this is the first section
 ** and this
 is another section"))))
-    (testing "boring with empty lines"
+    (testing "boring org file with empty lines"
       (is (=[:S
              [:headline [:stars "*"] [:title "hello" "world"]]
              [:content-line "this is the first section"]

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -673,6 +673,9 @@ is another section"))))))
 
 (deftest text
   (let [parse #(parser/org % :start :text)]
+    (testing "stop parsing text at EOL"
+      (is (= [:text [:text-normal "abc "]]
+             (parse "abc "))))
     (testing "parse text that contains style delimiter"
       (is (= [:text [:text-normal "a"] [:text-normal "/b"]]
              (parse "a/b"))))

--- a/test/org_parser/transform_test.cljc
+++ b/test/org_parser/transform_test.cljc
@@ -1,6 +1,5 @@
 (ns org-parser.transform-test
   (:require [org-parser.transform :as sut]
-            [org-parser.parser :as parser]
             #?(:clj [clojure.test :refer :all]
                :cljs [cljs.test :refer-macros [deftest is testing]])))
 
@@ -13,57 +12,3 @@
   (testing "helper fn"
     (is (= ["hello" "world"]
            (#'sut/property :title props)))))
-
-
-(deftest append
-  (testing "already in content block"
-    (is (= [[:content "hello\nworld\n"]]
-           (#'sut/append [[:content "hello\n"]] "world")))))
-
-
-(deftest reducer
-  (testing "content-line begins block"
-    (is (= [[:headline] [:content "hello world\n"]]
-           (#'sut/reducer [[:headline]] [:content-line "hello world"])))))
-
-
-(def parse-tree
-  [:S
-   [:headline [:stars "*"] [:title "hello" "world"]]
-   [:content-line [:text [:text-normal "this is the first section"]]]
-   [:empty-line]
-   [:headline [:stars "**"] [:title "and" "this"]]
-   [:empty-line]
-   [:content-line [:text [:text-normal "is another section"]]]])
-
-
-(def transformed
-  [[:headline {:level 1, :title "hello world"}]
-   [:content
-    {:raw "this is the first section\n\n",
-     :parsed [[:content-line [:text [:text-normal "this is the first section"]]]
-              [:empty-line]]}]
-   [:headline {:level 2, :title "and this"}]
-   [:content
-    {:raw "\nis another section\n",
-     :parsed [[:empty-line]
-              [:content-line [:text [:text-normal "is another section"]]]]}
-    ]])
-
-
-(deftest regression
-  (testing "`transform` works on structures provided by parser"
-    (let [parse parser/org]
-      (is (= parse-tree
-             (parse "* hello world
-this is the first section
-
-** and this
-
-is another section"))))))
-
-
-(deftest transform
-  (testing "a full parsetree"
-    (is (= transformed
-           (sut/transform parse-tree)))))

--- a/test/org_parser/transform_test.cljc
+++ b/test/org_parser/transform_test.cljc
@@ -30,18 +30,25 @@
 (def parse-tree
   [:S
    [:headline [:stars "*"] [:title "hello" "world"]]
-   [:content-line "this is the first section"]
+   [:content-line [:text [:text-normal "this is the first section"]]]
    [:empty-line]
    [:headline [:stars "**"] [:title "and" "this"]]
    [:empty-line]
-   [:content-line "is another section"]])
+   [:content-line [:text [:text-normal "is another section"]]]])
 
 
 (def transformed
   [[:headline {:level 1, :title "hello world"}]
-   [:content "this is the first section\n\n"]
+   [:content
+    {:raw "this is the first section\n\n",
+     :parsed [[:content-line [:text [:text-normal "this is the first section"]]]
+              [:empty-line]]}]
    [:headline {:level 2, :title "and this"}]
-   [:content "\nis another section\n"]])
+   [:content
+    {:raw "\nis another section\n",
+     :parsed [[:empty-line]
+              [:content-line [:text [:text-normal "is another section"]]]]}
+    ]])
 
 
 (deftest regression


### PR DESCRIPTION
This PR is the successor of #27.

The goal of this PR is to enable the EBNF parser to parse details in the content after a headline, e.g. links, timestamps, …

Closes #26
Closes #30 

- [x] Update parser tests
- [x] Update transformers to return `:raw` along with `:ast`
- [x] Update transformer tests
- [x] Update core tests