### PR TITLE
Parse headline title as text, update transform and render

### DIFF
--- a/README.org
+++ b/README.org
@@ -154,8 +154,7 @@ Run =lein run file.org=, for example:
 #+end_src
 
 #+RESULTS:
-: {:headlines [{:headline {:level 1, :title "Header with repeater"}}]}
-: 
+: {:headlines [{:headline {:level 1, :title [[:text-sty-bold "Header"] [:text-normal " with repeater"]], :planning [[:planning-info [:planning-keyword [:planning-kw-scheduled]] [:timestamp-active [:ts-inner [:ts-inner-wo-time [:ts-date "2019-11-27"] [:ts-day "Wed"]] [:ts-modifiers [:ts-repeater [:ts-repeater-type "+"] [:ts-mod-value "1"] [:ts-mod-unit "d"]]]]]]], :tags []}}]}
 
 ** NodeJS
 
@@ -170,7 +169,7 @@ Then run =./target/org-parser.js file.org=, for example:
 #+end_src
 
 #+RESULTS:
-: {"headlines":[{"headline":{"level":1,"title":"Header with repeater"}}]}
+: {"headlines":[{"headline":{"level":1,"title":[["text-sty-bold","Header"],["text-normal"," with repeater"]],"planning":[["planning-info",["planning-keyword",["planning-kw-scheduled"]],["timestamp-active",["ts-inner",["ts-inner-wo-time",["ts-date","2019-11-27"],["ts-day","Wed"]],["ts-modifiers",["ts-repeater",["ts-repeater-type","+"],["ts-mod-value","1"],["ts-mod-unit","d"]]]]]]],"tags":[]}}]}
 
 ** Java
 
@@ -185,8 +184,7 @@ Then run =java -jar target/uberjar/org-parser-*-SNAPSHOT-standalone.jar file.org
 #+end_src
 
 #+RESULTS:
-: {:headlines [{:headline {:level 1, :title "Header with repeater"}}]}
-: 
+: {:headlines [{:headline {:level 1, :title [[:text-sty-bold "Header"] [:text-normal " with repeater"]], :planning [[:planning-info [:planning-keyword [:planning-kw-scheduled]] [:timestamp-active [:ts-inner [:ts-inner-wo-time [:ts-date "2019-11-27"] [:ts-day "Wed"]] [:ts-modifiers [:ts-repeater [:ts-repeater-type "+"] [:ts-mod-value "1"] [:ts-mod-unit "d"]]]]]]], :tags []}}]}
 
 Note: The =*= character must be replaced with the current version number of org-parser.
 See the clojars badge at the [[https://github.com/200ok-ch/org-parser#general][top of this README]].

--- a/README.org
+++ b/README.org
@@ -147,7 +147,7 @@ possible.
 
 ** Clojure
 
-=lein run file.org=, for example:
+Run =lein run file.org=, for example:
 
 #+begin_src sh :results verbatim :exports both
   lein run test/org_parser/fixtures/schedule_with_repeater.org
@@ -163,7 +163,7 @@ First, compile =org-parser= with:
 
 : lein cljsbuild once main; chmod +x ./target/org-parser.js
 
-=./target/org-parser.js file.org=, for example:
+Then run =./target/org-parser.js file.org=, for example:
 
 #+begin_src sh :results verbatim :exports both
   ./target/org-parser.js test/org_parser/fixtures/schedule_with_repeater.org
@@ -178,7 +178,7 @@ First, compile =org-parser= with:
 
 : lein uberjar
 
-=java -jar target/uberjar/org-parser-*-SNAPSHOT-standalone.jar file.org=, for example:
+Then run =java -jar target/uberjar/org-parser-*-SNAPSHOT-standalone.jar file.org=, for example:
 
 #+begin_src sh :results verbatim :exports both
   java -jar target/uberjar/org-parser-*-SNAPSHOT-standalone.jar test/org_parser/fixtures/schedule_with_repeater.org

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -35,6 +35,8 @@ comment-line-rest = #".*"
 
 (* It's impractical to parse tags here because the title has to be
    parsed as text and text does not know where tags start.
+   Even if I make text-normal stopping at ':', it still would parse
+   more text after that.
    No problem, tags are extracted in the transformation step. *)
 headline = stars [s keyword] [s priority] [s comment-token] s title [ eol planning ]
 stars = #'\*+'

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -27,13 +27,15 @@ comment-line-rest = #".*"
 <anything-but-whitespace> = #"\S+"
 <anything-but-newline> = #"[^\n]+"
 
-headline = stars [s keyword] [s priority] [s comment-token] s title [s tags] [ eol planning ]
+(* It's impractical to parse tags here because the title has to be
+   parsed as text and text does not know where tags start.
+   No problem, tags are extracted in the transformation step. *)
+headline = stars [s keyword] [s priority] [s comment-token] s title [ eol planning ]
 stars = #'\*+'
 keyword = #"[A-Z]+"
 priority = <"[#"> #"[A-Z]" <"]">
 comment-token = <"COMMENT">
-(* TODO title text is more than just words; e.g. formatting and timestamps are allowed. *)
-title = !tags word {s !tags word}
+<title> = text
 tags = <':'> ( tag <':'> )+
 <tag> = #'[a-zA-Z0-9_@#%]+'
 

--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -7,7 +7,13 @@
 
 S = line*
 
-<line> = (empty-line / headline / clock / diary-sexp / affiliated-keyword-line / keyword-line / comment-line / todo-line / block-begin-line / block-end-line / dynamic-block-begin-line / dynamic-block-end-line / drawer-end-line / drawer-begin-line / list-item-line / footnote-line / fixed-width-line / horizontal-rule / table-line / content-line) eol
+<line> = (empty-line / headline / clock / diary-sexp /
+          affiliated-keyword-line / keyword-line / comment-line / todo-line /
+          block-begin-line / block-end-line /
+          dynamic-block-begin-line / dynamic-block-end-line /
+          drawer-end-line / drawer-begin-line /
+          list-item-line / footnote-line / fixed-width-line /
+          horizontal-rule / table-line / content-line) eol
 
 (* TODO delete empty-line token? because it discards whitespace which may not be desired. *)
 empty-line = "" | #"\s+"
@@ -91,6 +97,7 @@ noparse-block-content = #'((.|[\r\n])*?[\r\n](?=[\t ]*#\+(END|end)_))|'
 
 (* Greater "normal" blocks where content is parsed *)
 greater-block = block-begin-line <eol> line* block-end-line
+(* TODO use negative look-ahead to stop before first block-end-line *)
 block-begin-line = [s] <block-begin-marker> block-name [s block-parameters] [s]
 block-name = #"\S+"
 block-parameters = anything-but-newline

--- a/src/org_parser/core.cljc
+++ b/src/org_parser/core.cljc
@@ -13,6 +13,10 @@
       parser/org
       transform/transform))
 
+#_(read-str "** headline _underlined_ / +strikethrough+  :tag:baz:  \n foo/bar")
+#_(read-str "* headline/foo")
+#_(read-str "foo/bar")
+
 (defn write-str
   "Converts x to a ORG-formatted string. Takes optional Options."
   [x & options]

--- a/src/org_parser/render.cljc
+++ b/src/org_parser/render.cljc
@@ -22,6 +22,11 @@
 (defn- serialize-text-element [[tag text]]
   (case tag
     :text-bold (str "*" text "*")
+    :text-bold (str "/" text "/")
+    :text-bold (str "_" text "_")
+    :text-bold (str "+" text "+")
+    :text-bold (str "=" text "=")
+    :text-bold (str "~" text "~")
     text))
 
 (defn- serialize-text [elements]

--- a/src/org_parser/render.cljc
+++ b/src/org_parser/render.cljc
@@ -21,12 +21,12 @@
 
 (defn- serialize-text-element [[tag text]]
   (case tag
-    :text-bold (str "*" text "*")
-    :text-bold (str "/" text "/")
-    :text-bold (str "_" text "_")
-    :text-bold (str "+" text "+")
-    :text-bold (str "=" text "=")
-    :text-bold (str "~" text "~")
+    :text-sty-bold (str "*" text "*")
+    :text-sty-italic (str "/" text "/")
+    :text-sty-underlined (str "_" text "_")
+    :text-sty-strikethrough (str "+" text "+")
+    :text-sty-verbatim (str "=" text "=")
+    :text-sty-code (str "~" text "~")
     text))
 
 (defn- serialize-text [elements]
@@ -37,7 +37,7 @@
 (defn- serialize-headline* [headline]
   (str/join " "
             [(apply str (repeat (:level headline) "*"))
-             (serialize-text (:text headline))]))
+             (serialize-text (:title headline))]))
 
 (defn- serialize-section [{:keys [ast]}]
   ast)

--- a/src/org_parser/render.cljc
+++ b/src/org_parser/render.cljc
@@ -19,13 +19,15 @@
 ;; deserialized org data structure back to an org string. This needs
 ;; to be extenden to the full feature scope.
 
+(defn- serialize-text-element [[tag text]]
+  (case tag
+    :text-bold (str "*" text "*")
+    text))
 
-(defn- serialize-text
-  ([_ & _] "Hello World")
-  ;; TODO fix this and add text-* things
-  ;; ([[:text-normal s]]  s)
-  ;; ([[:text-bold s]]    (str/concat "*" s "*"))
-  )
+(defn- serialize-text [elements]
+  (apply str (map serialize-text-element elements)))
+
+#_(serialize-text [[:text-normal "hello "] [:text-bold "world"] [:asdf "!"]])
 
 (defn- serialize-headline* [headline]
   (str/join " "

--- a/src/org_parser/render.cljc
+++ b/src/org_parser/render.cljc
@@ -2,6 +2,8 @@
   (:require [clojure.string :as str]
             #?(:clj [clojure.data.json :as json])))
 
+;; See also export_org.js in https://github.com/200ok-ch/organice for inspirations
+
 
 ;; FIXME: delete the next 2 functions because it's not the
 ;; responsiblity of org-parser to render edn or json
@@ -18,10 +20,17 @@
 ;; to be extenden to the full feature scope.
 
 
+(defn- serialize-text
+  ([_ & _] "Hello World")
+  ;; TODO fix this and add text-* things
+  ;; ([[:text-normal s]]  s)
+  ;; ([[:text-bold s]]    (str/concat "*" s "*"))
+  )
+
 (defn- serialize-headline* [headline]
   (str/join " "
             [(apply str (repeat (:level headline) "*"))
-             (:title headline)]))
+             (serialize-text (:text headline))]))
 
 (defn- serialize-section [{:keys [ast]}]
   ast)

--- a/src/org_parser/transform.cljc
+++ b/src/org_parser/transform.cljc
@@ -6,6 +6,8 @@
 
 (def conjv (comp vec conj))
 
+(def consv (comp vec cons))
+
 
 (defmulti reducer
   "The reducer multi method takes a RESULT and an AST and dispatches
@@ -14,9 +16,7 @@
   (fn [_ line _] (first line)))
 
 
-;; add the given ast to the section of the last headline or to the
-;; preamble if there are no headlines yet
-(defmethod reducer :default [state ast raw]
+(defn- append-to-document [state ast raw]
   (let [loc (if-let [headlines (state :headlines)]
               [:headlines (dec (count headlines)) :section]
               [:preamble :section])]
@@ -25,6 +25,12 @@
         (update-in (conj loc :ast) conjv ast)
         ;; append raw string to :raw
         (update-in (conj loc :raw) conjv raw))))
+
+
+;; add the given ast to the section of the last headline or to the
+;; preamble if there are no headlines yet
+(defmethod reducer :default [state ast raw]
+  (append-to-document state ast raw))
 
 
 #_(transform (org-parser.parser/org "* hello\n** world\n\nasdf"))
@@ -60,17 +66,32 @@
 
 ;; content-line needs to simply drop the keyword
 (defmethod reducer :content-line [state [_ ast] raw]
-  (reducer state ast raw))
+  (append-to-document state ast raw))
+
+
+(defn- text-reducer [accu element]
+  (let [keep (butlast accu)
+        [last-key content] (last accu)]
+  (if (= last-key (first element))
+    (conj keep [last-key (str content (last element))])
+    (conj accu element))))
+
+#_(text-reducer [] [:text-normal "asdf"])
+#_(text-reducer [[:text-normal "asdf"]] [:text-normal "asdf"])
+#_(text-reducer [[:text-bold "asdf"]] [:text-normal "asdf"])
+#_(text-reducer [[:text-normal "asdf"]] [:text-bold "asdf"])
+
 
 ;; Merge consecutive :text-normal inside a :text list. They come from
 ;; the parser stopping at any special character like '*', '/', ...
-;; TODO
-;(defmethod reducer :text [state [_ ast] raw]
-;  (fold text [] #((cons %1 %2))))
-;; fold (right to left) with lambda:
-;;   if (head accu) is :text-normal AND current is :text-normal
-;;       then (cons (str/concat current (head accu)) (tail accu))
-;;       else (cons current accu)
+(defmethod reducer :text [state [_ & ast] raw]
+  (append-to-document state (consv :text (reduce text-reducer [] ast)) raw))
+
+
+(comment
+  (reducer {} [:text [:text-normal "a"] [:text-normal "/b"]] "a/b")
+  {:preamble {:section {:ast [[:text [:text-normal "a/b"]]], :raw ["a/b"]}}}
+  )
 
 (defn- wrap-raw [reducer raw]
   (fn [agg ast]

--- a/src/org_parser/transform.cljc
+++ b/src/org_parser/transform.cljc
@@ -43,7 +43,8 @@
   (->> props
        (filter #(= prop (first %)))
        first
-       (drop 1)))
+       (drop 1)
+       vec))
 
 
 (defmethod reducer :headline [state [_ & properties] raw]
@@ -54,15 +55,21 @@
         title (->> properties
                    (property :text))
         tags (->>  []) ;; TODO extract tags from the last element of :text if it's a :text-normal; empty otherwise;
-                            ;; use regex #'\s+(:[a-zA-Z0-9_@#%]+)+:\s*$' (see EBNF), if it is matching remove it from the :text-normal, trim it and split by ':'
+        ;; use regex #'\s+(:[a-zA-Z0-9_@#%]+)+:\s*$' (see EBNF), if it is matching remove it from the :text-normal, trim it and split by ':'
         ]
     ;; a headline introduces a new headline
     (update state :headlines conjv {:headline {:level level
                                                :title title
+                                               :planning (->> properties (property :planning))
                                                ;;:tags  tags
                                                ;; TODO much more to come, e.g. planning info (already parsed)
                                                }})))
 
+#_(reducer {} [:headline [:stars "*"] [:text [:text-normal "hello"]]
+               [:planning
+                [:planning-info
+                 [:planning-keyword [:planning-kw-closed]]
+                 [:timestamp [:timestamp-inactive [:ts-inner [:ts-inner-wo-time [:ts-date "2021-05-22"] [:ts-day "Sat"]] [:ts-modifiers]]]]]]] "")
 
 ;; content-line needs to simply drop the keyword
 (defmethod reducer :content-line [state [_ ast] raw]
@@ -72,9 +79,9 @@
 (defn- text-reducer [accu element]
   (let [keep (butlast accu)
         [last-key content] (last accu)]
-  (if (= last-key (first element))
-    (conj keep [last-key (str content (last element))])
-    (conj accu element))))
+    (if (= last-key (first element))
+      (conj keep [last-key (str content (last element))])
+      (conj accu element))))
 
 #_(text-reducer [] [:text-normal "asdf"])
 #_(text-reducer [[:text-normal "asdf"]] [:text-normal "asdf"])

--- a/src/org_parser/transform.cljc
+++ b/src/org_parser/transform.cljc
@@ -46,6 +46,18 @@
        (drop 1)
        vec))
 
+(defn- extract-tags [[_ s]]
+  "Given a [:text-normal 'xxx'], return the text-normal without tags
+  and the tags as a list."
+  (let [[tags & _] (re-find #"\s+(:[a-zA-Z0-9_@#%]+)+:\s*$" s)] ;; find tags by regex
+    (if (nil? tags)
+      [[:text-normal s] []]
+      [[:text-normal (subs s (- (count s) (count tags)))]
+       (->> tags str/trim #(str/split % #":") (filter #(not (= % ""))))])))
+;; trim the string, then split by ":", then only take tags that are =! ""
+#_(->> "   :tag1:tag2:  " str/trim #(str/split % #":") (filter #(not (= % ""))))
+
+
 
 (defmethod reducer :headline [state [_ & properties] raw]
   (let [level (->> properties

--- a/test/org_parser/fixtures/schedule_with_repeater.org
+++ b/test/org_parser/fixtures/schedule_with_repeater.org
@@ -1,2 +1,2 @@
-* TODO Header with repeater
+* TODO *Header* with repeater
   SCHEDULED: <2019-11-27 Wed +1d>

--- a/test/org_parser/integration/section_test.cljc
+++ b/test/org_parser/integration/section_test.cljc
@@ -26,14 +26,18 @@
 
     :result
     {:headlines
-     [{:headline {:level 1
-                  :title [[:text-normal "hello world"]]}
+     [{:headline
+       {:level 1,
+        :title [[:text-normal "hello world"]],
+        :planning [],
+        :tags []},
        :section
-       {:raw ["this is the first section" "this line has *bold text*"]
-        :ast [[:text [:text-normal "this is the first section"]]
-              [:text
-               [:text-normal "this line has "]
-               [:text-sty-bold "bold text"]]]}}]}}
+       {:ast
+        [[:text [:text-normal "this is the first section"]]
+         [:text
+          [:text-normal "this line has "]
+          [:text-sty-bold "bold text"]]],
+        :raw ["this is the first section" "this line has *bold text*"]}}]}}
 
    ;; next sample here:
    ;; {:input ...
@@ -45,8 +49,8 @@
 (deftest section
   (doseq [{:keys [input ast result output]} samples]
     (let [ast* (parser/org input)]
-      (if ast (is (= ast ast*)))
-      (if result (is (= result (transform/transform ast*)))))))
+      (testing "AST matches expected AST" (is (= ast ast*)))
+      (testing "transformed AST matches expected transformed AST" (is (= result (transform/transform ast*)))))))
 
 
 #_(-> samples first :input parser/org transform/transform)

--- a/test/org_parser/integration/section_test.cljc
+++ b/test/org_parser/integration/section_test.cljc
@@ -17,7 +17,7 @@
 
     :ast
     [:S
-     [:headline [:stars "*"] [:title "hello" "world"]]
+     [:headline [:stars "*"] [:text [:text-normal "hello world"]]]
      [:content-line [:text [:text-normal "this is the first section"]]]
      [:content-line
       [:text
@@ -27,7 +27,7 @@
     :result
     {:headlines
      [{:headline {:level 1
-                  :title "hello world"}
+                  :title [[:text-normal "hello world"]]}
        :section
        {:raw ["this is the first section" "this line has *bold text*"]
         :ast [[:text [:text-normal "this is the first section"]]

--- a/test/org_parser/parser_mean_test.cljc
+++ b/test/org_parser/parser_mean_test.cljc
@@ -6,5 +6,5 @@
 (deftest headline
   (let [parse #(parser/org % :start :headline)]
     (testing "with crazy characters in title"
-      (is (= [:headline [:stars "*****"] [:title "hello" "wörld⛄" ":"]]
+      (is (= [:headline [:stars "*****"] [:text [:text-normal "hello wörld⛄ :"]]]
              (parse "***** hello wörld⛄ :"))))))

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -73,27 +73,27 @@
 (deftest headline
   (let [parse #(parser/org % :start :headline)]
     (testing "boring"
-      (is (= [:headline [:stars "*"] [:title "hello" "world"]]
+      (is (= [:headline [:stars "*"] [:text [:text-normal "hello world"]]]
              (parse "* hello world"))))
     (testing "with priority"
-      (is (= [:headline [:stars "**"] [:priority "A"] [:title "hello" "world"]]
+      (is (= [:headline [:stars "**"] [:priority "A"] [:text [:text-normal "hello world"]]]
              (parse "** [#A] hello world"))))
     (testing "with tags"
-      (is (= [:headline [:stars "***"] [:title "hello" "world"] [:tags "the" "end"]]
+      (is (= [:headline [:stars "***"] [:text [:text-normal "hello world :the:end:"]]]
              (parse "*** hello world :the:end:"))))
     (testing "with priority and tags"
-      (is (= [:headline [:stars "****"] [:priority "B"] [:title "hello" "world"] [:tags "the" "end"]]
+      (is (= [:headline [:stars "****"] [:priority "B"] [:text [:text-normal "hello world :the:end:"]]]
              (parse "**** [#B] hello world :the:end:"))))
     (testing "title cannot have multiple lines"
       (is (insta/failure? (parse "* a\nb"))))
     (testing "with todo keyword"
-      (is (= [:headline [:stars "*"] [:keyword "TODO"] [:title "hello" "world"]]
+      (is (= [:headline [:stars "*"] [:keyword "TODO"] [:text [:text-normal "hello world"]]]
              (parse "* TODO hello world"))))
     (testing "with todo keyword and comment flag"
-      (is (= [:headline [:stars "*"] [:keyword "TODO"] [:comment-token] [:title "hello" "world"]]
+      (is (= [:headline [:stars "*"] [:keyword "TODO"] [:comment-token] [:text [:text-normal "hello world"]]]
              (parse "* TODO COMMENT hello world"))))
     (testing "with comment flag but without todo keyword or prio: interpret COMMENT as keyword"
-      (is (= [:headline [:stars "*****"] [:keyword "COMMENT"] [:title "hello" "world"]]
+      (is (= [:headline [:stars "*****"] [:keyword "COMMENT"] [:text [:text-normal "hello world"]]]
              (parse "***** COMMENT hello world"))))
     (testing "headline with planning info in next line"
       (is (= [:headline [:stars "*"] [:title "hello"]
@@ -151,9 +151,9 @@
   (let [parse parser/org]
     (testing "boring org file"
       (is (= [:S
-              [:headline [:stars "*"] [:title "hello" "world"]]
+              [:headline [:stars "*"] [:text [:text-normal "hello world"]]]
               [:content-line [:text [:text-normal "this is the first section"]]]
-              [:headline [:stars "**"] [:title "and" "this"]]
+              [:headline [:stars "**"] [:text [:text-normal "and this"]]]
               [:content-line [:text [:text-normal "is another section"]]]]
              (parse "* hello world
 this is the first section
@@ -161,10 +161,10 @@ this is the first section
 is another section"))))
     (testing "boring org file with empty lines"
       (is (=[:S
-             [:headline [:stars "*"] [:title "hello" "world"]]
+             [:headline [:stars "*"] [:text [:text-normal "hello world"]]]
              [:content-line [:text [:text-normal "this is the first section"]]]
              [:empty-line]
-             [:headline [:stars "**"] [:title "and" "this"]]
+             [:headline [:stars "**"] [:text [:text-normal "and this"]]]
              [:empty-line]
              [:content-line [:text [:text-normal "is another section"]]]]
             (parse "* hello world

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -96,7 +96,7 @@
       (is (= [:headline [:stars "*****"] [:keyword "COMMENT"] [:text [:text-normal "hello world"]]]
              (parse "***** COMMENT hello world"))))
     (testing "headline with planning info in next line"
-      (is (= [:headline [:stars "*"] [:title "hello"]
+      (is (= [:headline [:stars "*"] [:text [:text-normal "hello"]]
               [:planning
               [:planning-info
                [:planning-keyword [:planning-kw-closed]]


### PR DESCRIPTION
- [x] Parse headline title as text
- [x] First, merge #40 and #42
- [x] Extract tags from headline in transform step
- [x] Join consecutive `:text-normal` in text
- [x] Join consecutive `:text-normal` in headline
- [x] Write render function for `:text`
- [x] Update README samples