### PR TITLE
doc: Move to Libera.Chat from Freenode

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,17 +12,49 @@ Community chat: #organice on IRC [[https://freenode.net/][Freenode]], or [[https
 
 It can be used from JavaScript, Java, Clojure and ClojureScript!
 
-** Why is this project useful
+** Why is this project useful / Rationale
 
-To our knowledge, there is no formal specification of Org. But there
-is a [[https://orgmode.org/worg/dev/org-syntax.html]['spec' written in prose]] which lead to the [[https://orgmode.org/worg/dev/org-element-api.html][reference
-implementation of Org in Emacs]].
+Org mode in Emacs is implemented in [[http://git.savannah.gnu.org/cgit/emacs/org-mode.git/tree/lisp/org-element.el][org-element.el]] ([[https://orgmode.org/worg/dev/org-element-api.html][API
+documentation]]). The [[https://orgmode.org/worg/dev/org-syntax.html][spec for the Org syntax is written in prose]].
 
-Working on our web-based Org implementation [[https://github.com/200ok-ch/organice/][organice]], we have seen how
-brittle existing libraries can be. It would be nice to have a proper
-BNF based parser and a set of tests behind that. =org-parser=
-strives to be that. It provides a higher-level data structure that is
-easy to consume for an application working with Org mode data.
+This is already great work, yet it has some drawbacks:
+
+1. The spec is not machine readable. Hence, there can be drift between
+   documentation and implementation. In fact, during the development
+   of [[https://github.com/200ok-ch/organice/][organice]], our web-based Org implementation with great mobile
+   phone support, and =org-parser= we have encountered drift.
+2. org-element.el is naturally written in Emacs lisp and makes strong
+   use of Emacs as a text-processor. Hence, its code can only be used
+   within Emacs.
+
+While writing the official spec already is an amazing effort in the
+standardization of the Org format, the power of Org is so enticing
+that many want to use it outside of Emacs, as well. Since
+org-element.el only runs in Emacs, this caused a myriad of
+implementations for other platforms (JavaScript, Rust, Go, Java, etc)
+to have been created. Most implementations are only partial, and more
+importantly each of them creates another island. Since they are just
+as programming language dependent as org-element.el, it is impossible
+to share logic between them.
+
+=org-parser= aims at alleviating both these issues. It documents the
+syntax in a standard and machine readable notation (EBNF). And the
+reference implementation is done in a way that it runs on the
+established virtual machines of Java and JavaScript. Hence,
+=org-parser= can be used from all programming languages running on
+those virtual machines. =org-parser= provides a higher-level data
+structure that is easy to consume for an application working with Org
+mode data. Even if your application is not running on the Java or
+JavaScript virtual machines, you can embed =org-parser= as a
+command-line application. Lastly, =org-parser= brings a strong test
+suite to document the reference implementation in yet another
+unambiguous way.
+
+It is our aim that =org-parser= can be the foundation on which many
+Org mode applications in many different languages can be built. The
+applications using =org-parser= can then focus on implementing user
+facing features and don’t have to worry about the implementation of
+the Org syntax itself.
 
 ** Architecture
 
@@ -155,7 +187,7 @@ possible.
 
 #+RESULTS:
 : {:headlines [{:headline {:level 1, :title "Header with repeater"}}]}
-: 
+:
 
 ** NodeJS
 
@@ -186,7 +218,7 @@ First, compile =org-parser= with:
 
 #+RESULTS:
 : {:headlines [{:headline {:level 1, :title "Header with repeater"}}]}
-: 
+:
 
 Note: The =*= character must be replaced with the current version number of org-parser.
 See the clojars badge at the [[https://github.com/200ok-ch/org-parser#general][top of this README]].

--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@
 
 #+html: <a href="https://clojars.org/org-parser"><img src="https://img.shields.io/clojars/v/org-parser.svg?color=brightgreen" alt="Clojars Project" /></a>
 
-Community chat: #organice on IRC [[https://freenode.net/][Freenode]], or [[https://matrix.to/#/!DfVpGxoYxpbfAhuimY:matrix.org?via=matrix.org&via=ungleich.ch][#organice:matrix.org]] on Matrix
+Community chat: #organice on IRC [[https://libera.chat/][Libera.Chat]], or [[https://matrix.to/#/!DfVpGxoYxpbfAhuimY:matrix.org?via=matrix.org&via=ungleich.ch][#organice:matrix.org]] on Matrix
 
 ** What does this project do?
 


### PR DESCRIPTION
This PR precedes the following chat message that I'll be posting in #organice, soon:

To pick the Matrix-IRC bridge topic up again: It seems that there's quite a bit of turmoil going on at our current IRC host Fr33-node. I'm not misspelling and using l33t to be cool, but because there are various reports of channels being systematically taken over that mention various keywords. I'm trying not to trip any keyword detector.

The issue with Fr33-node is pretty big. It started with this announcement one week ago: https://news.ycombinator.com/item?id=27207734

There's many follow up blog posts from various sources on the topic. Personally, I have many people seen leave the network for the (not) aforementioned new network.

Now, the even more interesting part is that Fr33-node started to take over channels and banning operators and moderators who were talking about this topic. Examples from today:

- https://news.ycombinator.com/item?id=27289071
- https://news.ycombinator.com/item?id=27287750 

I'm deliberately linking to Hackernews to not trip keyword detectors, but also to show off-channel discussion of the topic.

As for #organice, we have been at Fr33-node as well as Matrix, because it is my understanding that these are well established places for proper discussion around FOSS projects. There seems to be enough evidence that Fr33-node is not such a place anymore. I'm not taking immediate action and will leave appropriate time for everybody to read these lines. There is no Matrix bridge to the new IRC network, yet. But there's work underway (see issue 1324 in https://github.com/matrix-org/matrix-appservice-irc). Again, I'm not linking to the issue directly, because it might unfurl the title which might lead to a ban due to using the new networks name. The migration plan is as follows:

- Close this channel soonish.
- Reopen #organice as a Matrix only channel.
- In the meantime, there's already a registered channel #organice at this new IRC network (the Readme of both organice and org-parser already point to it).
  - NB: Since there is no Matrix/IRC bridge, I will not be there all the time. But the channel is registered and other people can step up any time and ask for Ops. If they have contributed to organice and are good IRC citizens, then I'll be more than happy to oblige. To promote people in this channel is something I couldn't do so far, because even I have only be +m and couldn't hand out any permissions due to how the current bridge is set up-_-

By separating the Matrix and IRC channels, there will be no more auto-kicking. It will fragment the discussion, unfortunately, but having every user kicked every 30 days seems worse to me. When this is handled differently in the new Matrix/IRC bridge, then we can bridge the channels, again.

In any case, if this channel is taken over at any point, the canonical place for information (also what chat system is used for discussion) stays at https://github.com/200ok-ch/organice/. If you're kicked and don't know where to go, please check out the Readme.

My apologies for the inconvenience. And I hope I'll see you on the other side!