### PR TITLE
feat: Semantic tables

### DIFF
--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -13,7 +13,7 @@ S = line*
           dynamic-block-begin-line / dynamic-block-end-line /
           drawer-end-line / drawer-begin-line /
           list-item-line / footnote-line / fixed-width-line /
-          horizontal-rule / table-line / content-line) eol
+          horizontal-rule / table / content-line) eol
 
 (* TODO delete empty-line token? because it discards whitespace which may not be desired. *)
 empty-line = "" | #"\s+"
@@ -440,9 +440,6 @@ table-row-sep = #'\|-[-+|]*'
 table-row-cells = <'|'> table-cell { <'|'> table-cell } [ <'|'> ]
 table-cell = #'[^|\n]*'
 table-formula = [s] <'#+TBLFM: '> anything-but-newline
-
-(* TODO only as long as tables are not parsed as semantic blocks: *)
-<table-line> = table-tableel-sep / table-tableel-line / table-row / table-formula
 
 
 (* Clock, Diary Sexp and Planning

--- a/test/org_parser/fixtures/headlines_and_tables.org
+++ b/test/org_parser/fixtures/headlines_and_tables.org
@@ -8,5 +8,10 @@
 
 * Headline 2
 
-  | column 1 | column 2 |
-  | value 1  | value 2  |
+  | people     | age |
+  |------------+-----|
+  | bob        |  38 |
+  | max        |  42 |
+  |------------+-----|
+  | median age |  40 |
+  #+TBLFM: @4$2=vmean(@2..@-1)

--- a/test/org_parser/fixtures/headlines_and_tables.org
+++ b/test/org_parser/fixtures/headlines_and_tables.org
@@ -1,0 +1,12 @@
+* Headline 1
+
+  | first column 1 | first column 2 |
+  | first value 1  | first value 2  |
+
+  | second column 1 | second column 2 |
+  | second value 1  | second value 2  |
+
+* Headline 2
+
+  | column 1 | column 2 |
+  | value 1  | value 2  |

--- a/test/org_parser/fixtures/headlines_and_tables.org
+++ b/test/org_parser/fixtures/headlines_and_tables.org
@@ -15,3 +15,18 @@
   |------------+-----|
   | median age |  40 |
   #+TBLFM: @4$2=vmean(@2..@-1)
+
+* table.el style table
+
+  The option to use org tables and table.el tables is documented in
+  the spec: https://orgmode.org/worg/dev/org-syntax.html#Tables
+
+  Hence, =org-parser= should and does parse it!
+
+  +-----+-----+
+  | people | age |
+  +-----+-----+
+  | bob | 38 |
+  +-----+-----+
+  | max | 42 |
+  +-----+-----+

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -2,9 +2,9 @@
   (:refer-clojure :exclude [keyword])
   (:require [org-parser.parser :as parser]
             [instaparse.core :as insta]
-            #?(:clj [clojure.test :refer :all]
-               :cljs [cljs.test :refer-macros [deftest is testing]]
-                     [cljs-node-io.core :refer [slurp]])))
+            #?(:clj [clojure.test :refer :all])
+            #?(:cljs [cljs.test :refer-macros [deftest is testing]])
+            #?(:cljs [cljs-node-io.core :refer [slurp]])))
 
 
 ;; if parse is successful it returns a vector otherwise a map

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -1191,38 +1191,49 @@ is another section"))))))
   (testing "headlines and tables"
     (let [content (slurp "test/org_parser/fixtures/headlines_and_tables.org")]
       (is (= [:S
-              [:headline [:stars "*"] [:text [:text-normal "Headline 1"]]]
-              [:empty-line]
-              [:table
-               [:table-org
-                [:table-row
-                 [:table-row-cells
-                  [:table-cell " first column 1 "]
-                  [:table-cell " first column 2 "]]]
-                [:table-row
-                 [:table-row-cells
-                  [:table-cell " first value 1  "]
-                  [:table-cell " first value 2  "]]]]]
-              [:table
-               [:table-org
-                [:table-row
-                 [:table-row-cells
-                  [:table-cell " second column 1 "]
-                  [:table-cell " second column 2 "]]]
-                [:table-row
-                 [:table-row-cells
-                  [:table-cell " second value 1  "]
-                  [:table-cell " second value 2  "]]]]]
-              [:headline [:stars "*"] [:text [:text-normal "Headline 2"]]]
-              [:empty-line]
-              [:table
-               [:table-org
-                [:table-row
-                 [:table-row-cells
-                  [:table-cell " column 1 "]
-                  [:table-cell " column 2 "]]]
-                [:table-row
-                 [:table-row-cells
-                  [:table-cell " value 1  "]
-                  [:table-cell " value 2  "]]]]]]
+           [:headline [:stars "*"] [:text [:text-normal "Headline 1"]]]
+           [:empty-line]
+           [:table
+            [:table-org
+             [:table-row
+              [:table-row-cells
+               [:table-cell " first column 1 "]
+               [:table-cell " first column 2 "]]]
+             [:table-row
+              [:table-row-cells
+               [:table-cell " first value 1  "]
+               [:table-cell " first value 2  "]]]]]
+           [:table
+            [:table-org
+             [:table-row
+              [:table-row-cells
+               [:table-cell " second column 1 "]
+               [:table-cell " second column 2 "]]]
+             [:table-row
+              [:table-row-cells
+               [:table-cell " second value 1  "]
+               [:table-cell " second value 2  "]]]]]
+           [:headline [:stars "*"] [:text [:text-normal "Headline 2"]]]
+           [:empty-line]
+           [:table
+            [:table-org
+             [:table-row
+              [:table-row-cells
+               [:table-cell " people     "]
+               [:table-cell " age "]]]
+             [:table-row [:table-row-sep "|------------+-----|"]]
+             [:table-row
+              [:table-row-cells
+               [:table-cell " bob        "]
+               [:table-cell "  38 "]]]
+             [:table-row
+              [:table-row-cells
+               [:table-cell " max        "]
+               [:table-cell "  42 "]]]
+             [:table-row [:table-row-sep "|------------+-----|"]]
+             [:table-row
+              [:table-row-cells
+               [:table-cell " median age "]
+               [:table-cell "  40 "]]]
+             [:table-formula "@4$2=vmean(@2..@-1)"]]]]
              (parser/parse content))))))

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -3,7 +3,8 @@
   (:require [org-parser.parser :as parser]
             [instaparse.core :as insta]
             #?(:clj [clojure.test :refer :all]
-               :cljs [cljs.test :refer-macros [deftest is testing]])))
+               :cljs [cljs.test :refer-macros [deftest is testing]]
+                     [cljs-node-io.core :refer [slurp]])))
 
 
 ;; if parse is successful it returns a vector otherwise a map
@@ -1185,3 +1186,43 @@ is another section"))))))
                [:timestamp [:timestamp-inactive [:ts-inner [:ts-inner-wo-time [:ts-date "2021-05-21"] [:ts-day "Fri"]] [:ts-modifiers]]]]]]
              (parse "SCHEDULED: [2021-05-22 Sat 23:26]  DEADLINE: <2021-05-22 Sat>  CLOSED: [2021-05-21 Fri] "))))
     ))
+
+(deftest whole-files
+  (testing "headlines and tables"
+    (let [content (slurp "test/org_parser/fixtures/headlines_and_tables.org")]
+      (is (= [:S
+              [:headline [:stars "*"] [:text [:text-normal "Headline 1"]]]
+              [:empty-line]
+              [:table
+               [:table-org
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " first column 1 "]
+                  [:table-cell " first column 2 "]]]
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " first value 1  "]
+                  [:table-cell " first value 2  "]]]]]
+              [:table
+               [:table-org
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " second column 1 "]
+                  [:table-cell " second column 2 "]]]
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " second value 1  "]
+                  [:table-cell " second value 2  "]]]]]
+              [:headline [:stars "*"] [:text [:text-normal "Headline 2"]]]
+              [:empty-line]
+              [:table
+               [:table-org
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " column 1 "]
+                  [:table-cell " column 2 "]]]
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " value 1  "]
+                  [:table-cell " value 2  "]]]]]]
+             (parser/parse content))))))

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -1191,49 +1191,81 @@ is another section"))))))
   (testing "headlines and tables"
     (let [content (slurp "test/org_parser/fixtures/headlines_and_tables.org")]
       (is (= [:S
-           [:headline [:stars "*"] [:text [:text-normal "Headline 1"]]]
-           [:empty-line]
-           [:table
-            [:table-org
-             [:table-row
-              [:table-row-cells
-               [:table-cell " first column 1 "]
-               [:table-cell " first column 2 "]]]
-             [:table-row
-              [:table-row-cells
-               [:table-cell " first value 1  "]
-               [:table-cell " first value 2  "]]]]]
-           [:table
-            [:table-org
-             [:table-row
-              [:table-row-cells
-               [:table-cell " second column 1 "]
-               [:table-cell " second column 2 "]]]
-             [:table-row
-              [:table-row-cells
-               [:table-cell " second value 1  "]
-               [:table-cell " second value 2  "]]]]]
-           [:headline [:stars "*"] [:text [:text-normal "Headline 2"]]]
-           [:empty-line]
-           [:table
-            [:table-org
-             [:table-row
-              [:table-row-cells
-               [:table-cell " people     "]
-               [:table-cell " age "]]]
-             [:table-row [:table-row-sep "|------------+-----|"]]
-             [:table-row
-              [:table-row-cells
-               [:table-cell " bob        "]
-               [:table-cell "  38 "]]]
-             [:table-row
-              [:table-row-cells
-               [:table-cell " max        "]
-               [:table-cell "  42 "]]]
-             [:table-row [:table-row-sep "|------------+-----|"]]
-             [:table-row
-              [:table-row-cells
-               [:table-cell " median age "]
-               [:table-cell "  40 "]]]
-             [:table-formula "@4$2=vmean(@2..@-1)"]]]]
+              [:headline [:stars "*"] [:text [:text-normal "Headline 1"]]]
+              [:empty-line]
+              [:table
+               [:table-org
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " first column 1 "]
+                  [:table-cell " first column 2 "]]]
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " first value 1  "]
+                  [:table-cell " first value 2  "]]]]]
+              [:table
+               [:table-org
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " second column 1 "]
+                  [:table-cell " second column 2 "]]]
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " second value 1  "]
+                  [:table-cell " second value 2  "]]]]]
+              [:headline [:stars "*"] [:text [:text-normal "Headline 2"]]]
+              [:empty-line]
+              [:table
+               [:table-org
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " people     "]
+                  [:table-cell " age "]]]
+                [:table-row [:table-row-sep "|------------+-----|"]]
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " bob        "]
+                  [:table-cell "  38 "]]]
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " max        "]
+                  [:table-cell "  42 "]]]
+                [:table-row [:table-row-sep "|------------+-----|"]]
+                [:table-row
+                 [:table-row-cells
+                  [:table-cell " median age "]
+                  [:table-cell "  40 "]]]
+                [:table-formula "@4$2=vmean(@2..@-1)"]]]
+              [:headline [:stars "*"] [:text [:text-normal "table.el style table"]]]
+              [:empty-line]
+              [:content-line
+               [:text
+                [:text-normal
+                 "  The option to use org tables and table.el tables is documented in"]]]
+              [:content-line
+               [:text
+                ;; FIXME: URLs seem to get mangled. Ignoring it here,
+                ;; because this test is about org and table.el tables.
+                [:text-normal "  the spec: https:"]
+                [:text-normal "/"]
+                [:text-normal "/orgmode.org"]
+                [:text-normal "/worg"]
+                [:text-normal "/dev"]
+                [:text-normal "/org-syntax.html#Tables"]]]
+              [:empty-line]
+              [:content-line
+               [:text
+                [:text-normal "  Hence, "]
+                [:text-sty-verbatim "org-parser"]
+                [:text-normal " should and does parse it!"]]]
+              [:empty-line]
+              [:table
+               [:table-tableel
+                [:table-tableel-sep "+-----+-----+"]
+                [:table-tableel-line "| people | age |"]
+                [:table-tableel-sep "+-----+-----+"]
+                [:table-tableel-line "| bob | 38 |"]
+                [:table-tableel-sep "+-----+-----+"]
+                [:table-tableel-line "| max | 42 |"]
+                [:table-tableel-sep "+-----+-----+"]]]]
              (parser/parse content))))))


### PR DESCRIPTION
In #organice, we had a user ask for parsing of tables within Org files. I realized we could 'only' parse a complete table with noting the explicit starting point:

```
(parser/parse "| column 1 | column 2|" :start :table)

=> [:table [:table-org [:table-row [:table-row-cells [:table-cell " column 1 "] [:table-cell " column 2"]]]]]
```

The regular EBNF used line based parsing still. So I had the option to write a new reducer or check out what happens if I use the ENBF for `table`. 

Looks to me like 99.9999% of the work was done already and with this small change it just works(;

@schoettl Could you confirm? And great job on the prior work here!
