### PR TITLE
support shadow-cljs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
 
 .PHONY: build test testcode testjs testjar clean
 
-build: buildjs.sh buildjar.sh
+build: buildjar.sh
 	bash buildjar.sh
-	bash buildjs.sh
 # Order is important because one command deletes build artifacts of the other.
 # Also, not sure if this would stop correctly on error:
 # echo $^ | xargs -n 1 bash
 
-test: testcode-clj testcode-cljs testjs testjar
+test: testcode-clj testcode-cljs testjar
 
 testcode-clj:
 	lein test
@@ -17,15 +16,11 @@ testcode-cljs:
 	lein doo node once
 
 # Test by executing parser on test file and expect at least one line of output (grep .)
-testjs: build testjs.sh
-	bash testjs.sh | grep .
-
 testjar: build testjar.sh
 	bash testjar.sh | grep .
 
-
 # Filenames of :tangle files must be hardcoded :(
-buildjs.sh buildjar.sh testjs.sh testjar.sh: README.org
+buildjs.sh buildjar.sh testjar.sh: README.org
 	emacs --batch -l org $< -f org-babel-tangle
 
 clean:

--- a/README.org
+++ b/README.org
@@ -159,27 +159,25 @@ org-parser/org-parser {:mvn/version "0.1.4"}
 [org-parser "0.1.4"]
 #+END_SRC
 
-
 * Usage
   :PROPERTIES:
   :CUSTOM_ID: usage
   :END:
 
-At the moment, you can run =org-parser= from Clojure, Java or from
-NodeJS. Other targets which are hosted on the JVM or on JavaScript are
-possible.
+At the moment, you can run =org-parser= from Clojure, ClojureScript,
+or Java. Other targets which are hosted on the JVM or on JavaScript
+are possible.
 
 ** Clojure Library
 
  #+BEGIN_SRC clojure :exports both
    (ns hello-world.core
-     (:require [org-parser.parser :refer [parse]])
-     (:require [org-parser.core :refer [read-str write-str]]))
-   
-   (parse "* Headline")
-   
-   (read-str "* Headline")
-   (write-str (read-str "* Headline"))
+     (:require [org-parser.parser :refer [parse]]
+               [org-parser.core :refer [read-str write-str]]))
+
+   (prn (parse "* Headline"))
+   (prn (read-str "* Headline"))
+   (println (write-str (read-str "* Headline")))
  #+END_SRC
 
  #+RESULTS:
@@ -197,23 +195,6 @@ Run =lein run file.org=, for example:
 
 #+RESULTS:
 : {:headlines [{:headline {:level 1, :title [[:text-sty-bold "Header"] [:text-normal " with repeater"]], :planning [[:planning-info [:planning-keyword [:planning-kw-scheduled]] [:timestamp-active [:ts-inner [:ts-inner-wo-time [:ts-date "2019-11-27"] [:ts-day "Wed"]] [:ts-modifiers [:ts-repeater [:ts-repeater-type "+"] [:ts-mod-value "1"] [:ts-mod-unit "d"]]]]]]], :tags []}}]}
-
-** NodeJS
-
-First, compile =org-parser= with:
-
-#+begin_src sh :exports code :results silent :tangle buildjs.sh
-  lein cljsbuild once main && chmod +x ./target/org-parser.js
-#+end_src
-
-Then run =./target/org-parser.js file.org=, for example:
-
-#+begin_src sh :results verbatim :exports both :tangle testjs.sh
-  ./target/org-parser.js test/org_parser/fixtures/schedule_with_repeater.org
-#+end_src
-
-#+RESULTS:
-: {"headlines":[{"headline":{"level":1,"title":[["text-sty-bold","Header"],["text-normal"," with repeater"]],"planning":[["planning-info",["planning-keyword",["planning-kw-scheduled"]],["timestamp-active",["ts-inner",["ts-inner-wo-time",["ts-date","2019-11-27"],["ts-day","Wed"]],["ts-modifiers",["ts-repeater",["ts-repeater-type","+"],["ts-mod-value","1"],["ts-mod-unit","d"]]]]]]],"tags":[]}}]}
 
 ** Java
 

--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,9 @@
             :url "https://www.gnu.org/licenses/agpl-3.0.en.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/clojurescript "1.10.866"]
-                 [cljs-node-io "1.1.2"]
                  [org.clojure/data.json "1.0.0"]
                  [instaparse "1.4.10"]]
-  :main ^:skip-aot org-parser.core
+  :main ^:skip-aot org-parser.cli
   :target-path "target/%s"
   :repl-options {:init-ns org-parser.core}
   :plugins [[lein-cljsbuild "1.1.8"]

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "https://www.gnu.org/licenses/agpl-3.0.en.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/clojurescript "1.10.866"]
+                 [cljs-node-io "1.1.2"]
                  [org.clojure/data.json "1.0.0"]
                  [instaparse "1.4.10"]]
   :main ^:skip-aot org-parser.cli

--- a/src/org_parser/cli.clj
+++ b/src/org_parser/cli.clj
@@ -1,0 +1,13 @@
+(ns org-parser.cli
+  (:gen-class)
+  (:require [org-parser.core :as core]
+            [org-parser.render :as render]
+            [clojure.string :as str]))
+
+(defn -main [path & args]
+  (->> path
+       slurp
+       core/read-str
+       render/json
+       str/trim-newline
+       println))

--- a/src/org_parser/core.cljc
+++ b/src/org_parser/core.cljc
@@ -1,8 +1,6 @@
 (ns org-parser.core
   #?(:clj (:gen-class))
-  (:require ;;#?(:cljs [cljs.nodejs :as nodejs])
-            ;;#?(:cljs [cljs-node-io.core :refer [slurp]])
-            [org-parser.parser :as parser]
+  (:require [org-parser.parser :as parser]
             [org-parser.transform :as transform]
             [org-parser.render :as render]
             [clojure.string :as string]
@@ -23,17 +21,3 @@
   "Converts x to a ORG-formatted string. Takes optional Options."
   [x & options]
   (render/render x))
-
-;; (defn -main [path & args]
-;;   (->> path
-;;        slurp
-;;        read-str
-;;        #?(:clj render/edn)
-;;        #?(:cljs render/json)
-;;        string/trim-newline
-;;        println))
-
-;; #?(:cljs
-;;    (do
-;;      ;; (nodejs/enable-util-print!)
-;;      (set! *main-cli-fn* -main)))

--- a/src/org_parser/core.cljc
+++ b/src/org_parser/core.cljc
@@ -1,7 +1,7 @@
 (ns org-parser.core
   #?(:clj (:gen-class))
-  (:require #?(:cljs [cljs.nodejs :as nodejs])
-            #?(:cljs [cljs-node-io.core :refer [slurp]])
+  (:require ;;#?(:cljs [cljs.nodejs :as nodejs])
+            ;;#?(:cljs [cljs-node-io.core :refer [slurp]])
             [org-parser.parser :as parser]
             [org-parser.transform :as transform]
             [org-parser.render :as render]
@@ -24,16 +24,16 @@
   [x & options]
   (render/render x))
 
-(defn -main [path & args]
-  (->> path
-       slurp
-       read-str
-       #?(:clj render/edn)
-       #?(:cljs render/json)
-       string/trim-newline
-       println))
+;; (defn -main [path & args]
+;;   (->> path
+;;        slurp
+;;        read-str
+;;        #?(:clj render/edn)
+;;        #?(:cljs render/json)
+;;        string/trim-newline
+;;        println))
 
-#?(:cljs
-   (do
-     (nodejs/enable-util-print!)
-     (set! *main-cli-fn* -main)))
+;; #?(:cljs
+;;    (do
+;;      ;; (nodejs/enable-util-print!)
+;;      (set! *main-cli-fn* -main)))

--- a/src/org_parser/macros.clj
+++ b/src/org_parser/macros.clj
@@ -1,0 +1,5 @@
+(ns org-parser.macros
+  (:require [clojure.java.io :as io]))
+
+(defmacro inline [path]
+  (slurp (io/resource path)))

--- a/src/org_parser/parser.cljs
+++ b/src/org_parser/parser.cljs
@@ -1,11 +1,8 @@
 (ns org-parser.parser
-  (:require [instaparse.core :as insta :refer-macros [defparser]]
-            ;; [cljs.nodejs :as nodejs]
-            ))
+  (:require-macros [org-parser.macros :as macros])
+  (:require [instaparse.core :as insta :refer-macros [defparser]]))
 
-(def fs (js/require "fs"))
-
-(defparser parser (.readFileSync fs "resources/org.ebnf" "utf8"))
+(defparser parser (macros/inline "org.ebnf"))
 
 (defn parse [& args]
   (-> (apply parser args)


### PR DESCRIPTION
Based on #62 but without the dependency on shadow-cljs.

Removed the support for building an executable that runs on Node, as this would require using dependencies that are not available for other JS Runtimes.

The use of org-parser within Node (as a library) is still supported.