### PR TITLE
Add support for TODO keywords, priority and comment to read-str

### DIFF
--- a/resources/org.ebnf
+++ b/resources/org.ebnf
@@ -41,7 +41,7 @@ indent = #"[\t ]*"
    No problem, tags are extracted in the transformation step. *)
 headline = stars [s keyword] [s priority] [s comment-token] s title [ eol planning ]
 stars = #'\*+'
-keyword = #"[A-Z]+"
+keyword = !comment-token #"[A-Z]+"
 priority = <"[#"> #"[A-Z]" <"]">
 comment-token = <"COMMENT">
 <title> = text

--- a/src/org_parser/transform.cljc
+++ b/src/org_parser/transform.cljc
@@ -85,13 +85,22 @@
 #_(extract-tags-from-text [[:text-bold "bold"] [:text-x "foo"] [:text-normal "und  :tag:"]])
 
 (defmethod reducer :headline [state [_ & properties] raw]
-  (let [[title tags] (->> properties (property :text) extract-tags-from-text)
-        ]
-    (update state :headlines conjv {:headline {:level (->> properties (property :level) first)
-                                               :title title
-                                               :planning (->> properties (property :planning))
-                                               :tags tags
-                                               }})))
+  (let [[title tags] (->> properties (property :text) extract-tags-from-text)]
+    (update state :headlines
+            conjv {:headline {:level (->> properties (property :level) first)
+                              :title title
+                              :planning (->> properties (property :planning))
+                              :keyword (->> properties
+                                            (property :keyword)
+                                            first)
+                              :priority (->> properties
+                                             (property :priority)
+                                             first)
+                              ;; :commented? (->> properties
+                              ;;                  (property :comment-token)
+                              ;;                  (seq)
+                              ;;                  #_(not))
+                              :tags tags}})))
 
 
 ;; content-line needs to simply drop the keyword

--- a/src/org_parser/transform.cljc
+++ b/src/org_parser/transform.cljc
@@ -36,13 +36,20 @@
 #_(transform (org-parser.parser/parse "* hello\n** world\n\nasdf"))
 
 
+(defn- property-node
+  "Takes a PROP (a keyword) and a seq PROPS. Finds the occurence of
+  PROP in PROPS and returns the node."
+  [prop props]
+  (->> props
+       (filter #(= prop (first %)))
+       first))
+
 (defn- property
   "Takes a PROP (a keyword) and a seq PROPS. Finds the occurence of
   PROP in PROPS and returns a seq of its values."
   [prop props]
   (->> props
-       (filter #(= prop (first %)))
-       first
+       (property-node prop)
        (drop 1)
        vec))
 
@@ -96,10 +103,10 @@
                               :priority (->> properties
                                              (property :priority)
                                              first)
-                              ;; :commented? (->> properties
-                              ;;                  (property :comment-token)
-                              ;;                  (seq)
-                              ;;                  #_(not))
+                              :commented? (->> (doto properties prn)
+                                               (property-node :comment-token)
+                                               (seq)
+                                               (boolean))
                               :tags tags}})))
 
 

--- a/src/org_parser/transform.cljc
+++ b/src/org_parser/transform.cljc
@@ -103,7 +103,7 @@
                               :priority (->> properties
                                              (property :priority)
                                              first)
-                              :commented? (->> (doto properties prn)
+                              :commented? (->> properties
                                                (property-node :comment-token)
                                                (seq)
                                                (boolean))

--- a/test/org_parser/core_test.cljc
+++ b/test/org_parser/core_test.cljc
@@ -28,7 +28,7 @@
                         :priority nil,
                         :commented? false
                         :tags []}}]}))
-  #_(is (= (core/read-str "* COMMENT foo bar")
+  (is (= (core/read-str "* COMMENT foo bar")
          {:headlines [{:headline
                        {:level 1,
                         :title [[:text-normal "foo bar"]],

--- a/test/org_parser/core_test.cljc
+++ b/test/org_parser/core_test.cljc
@@ -8,3 +8,21 @@
   (testing "minimal"
     (let [minimal (slurp "test/org_parser/fixtures/minimal.org")]
       (is (= minimal (-> minimal core/read-str core/write-str))))))
+
+
+(deftest headline-data
+  (is (= (core/read-str "* TODO COMMENT foo bar")
+         {:headlines [{:headline
+                       {:level 1,
+                        :title [[:text-normal "foo bar"]],
+                        :planning [],
+                        :keyword "TODO",
+                        :priority nil,
+                        :tags []}}]}))
+  (is (= (core/read-str "* TODO [#B] foo bar")
+         {:headlines [{:headline {:level 1,
+                                  :title [[:text-normal "foo bar"]],
+                                  :planning [],
+                                  :keyword "TODO",
+                                  :priority "B",
+                                  :tags []}}]})))

--- a/test/org_parser/core_test.cljc
+++ b/test/org_parser/core_test.cljc
@@ -18,6 +18,7 @@
                         :planning [],
                         :keyword "TODO",
                         :priority nil,
+                        :commented? true
                         :tags []}}]}))
   (is (= (core/read-str "* TODO [#B] foo bar")
          {:headlines [{:headline {:level 1,
@@ -25,4 +26,5 @@
                                   :planning [],
                                   :keyword "TODO",
                                   :priority "B",
+                                  :commented? false
                                   :tags []}}]})))

--- a/test/org_parser/core_test.cljc
+++ b/test/org_parser/core_test.cljc
@@ -19,6 +19,24 @@
                                   :priority nil,
                                   :commented? false
                                   :tags []}}]}))
+  (is (= (core/read-str "* TODO foo bar")
+         {:headlines [{:headline
+                       {:level 1,
+                        :title [[:text-normal "foo bar"]],
+                        :planning [],
+                        :keyword "TODO",
+                        :priority nil,
+                        :commented? false
+                        :tags []}}]}))
+  #_(is (= (core/read-str "* COMMENT foo bar")
+         {:headlines [{:headline
+                       {:level 1,
+                        :title [[:text-normal "foo bar"]],
+                        :planning [],
+                        :keyword nil,
+                        :priority nil,
+                        :commented? true
+                        :tags []}}]}))
   (is (= (core/read-str "* TODO COMMENT foo bar")
          {:headlines [{:headline
                        {:level 1,
@@ -28,6 +46,14 @@
                         :priority nil,
                         :commented? true
                         :tags []}}]}))
+  (is (= (core/read-str "* [#B] foo bar")
+         {:headlines [{:headline {:level 1,
+                                  :title [[:text-normal "foo bar"]],
+                                  :planning [],
+                                  :keyword nil,
+                                  :priority "B",
+                                  :commented? false
+                                  :tags []}}]}))
   (is (= (core/read-str "* TODO [#B] foo bar")
          {:headlines [{:headline {:level 1,
                                   :title [[:text-normal "foo bar"]],

--- a/test/org_parser/core_test.cljc
+++ b/test/org_parser/core_test.cljc
@@ -11,6 +11,14 @@
 
 
 (deftest headline-data
+  (is (= (core/read-str "* foo bar")
+         {:headlines [{:headline {:level 1,
+                                  :title [[:text-normal "foo bar"]],
+                                  :planning [],
+                                  :keyword nil,
+                                  :priority nil,
+                                  :commented? false
+                                  :tags []}}]}))
   (is (= (core/read-str "* TODO COMMENT foo bar")
          {:headlines [{:headline
                        {:level 1,

--- a/test/org_parser/integration/section_test.cljc
+++ b/test/org_parser/integration/section_test.cljc
@@ -30,6 +30,9 @@
        {:level 1,
         :title [[:text-normal "hello world"]],
         :planning [],
+        :keyword nil
+        :priority nil
+        :commented? false
         :tags []},
        :section
        {:ast

--- a/test/org_parser/parser_test.cljc
+++ b/test/org_parser/parser_test.cljc
@@ -94,7 +94,7 @@
       (is (= [:headline [:stars "*"] [:keyword "TODO"] [:comment-token] [:text [:text-normal "hello world"]]]
              (parse "* TODO COMMENT hello world"))))
     (testing "with comment flag but without todo keyword or prio: interpret COMMENT as keyword"
-      (is (= [:headline [:stars "*****"] [:keyword "COMMENT"] [:text [:text-normal "hello world"]]]
+      (is (= [:headline [:stars "*****"] [:comment-token] [:text [:text-normal "hello world"]]]
              (parse "***** COMMENT hello world"))))
     (testing "headline with planning info in next line"
       (is (= [:headline [:stars "*"] [:text [:text-normal "hello"]]


### PR DESCRIPTION
This PR closes #68. It adds a few new keys to the headline maps in the result of `read-str` so that we preserve information like `TODO` / `NEXT` / etc., priority and whether the `COMMENT` keyword is present in the heading.